### PR TITLE
Swap out jboss marshalling artifacts.

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -47,6 +47,12 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-infinispan</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.marshalling</groupId>
+                    <artifactId>jboss-marshalling-osgi</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -85,6 +91,26 @@
             <artifactId>eddsa</artifactId>
         </dependency>
 
+        <dependency>
+            <!-- necessary for MR artifacts to be available
+            for >8 jre -->
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling</artifactId>
+        </dependency>
+
+        <dependency>
+            <!-- necessary for MR artifacts to be available
+            for >8 jre -->
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-river</artifactId>
+        </dependency>
+
+        <dependency>
+            <!-- necessary for MR artifacts to be available
+            for >8 jre -->
+            <groupId>org.jboss.marshalling</groupId>
+            <artifactId>jboss-marshalling-serial</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
         <version.fabric8.maven-plugin>4.2.0</version.fabric8.maven-plugin>
         <version.hdrhistogram>2.1.11</version.hdrhistogram>
         <version.javaparser>3.14.12</version.javaparser>
+        <version.marshalling>2.0.6.Final</version.marshalling>
         <version.junit>4.12</version.junit>
         <version.log4j2>2.11.1</version.log4j2>
         <version.metainf-services>1.8</version.metainf-services>
@@ -303,6 +304,24 @@
                 <groupId>com.github.javaparser</groupId>
                 <artifactId>javaparser-core</artifactId>
                 <version>${version.javaparser}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.marshalling</groupId>
+                <artifactId>jboss-marshalling</artifactId>
+                <version>${version.marshalling}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.marshalling</groupId>
+                <artifactId>jboss-marshalling-river</artifactId>
+                <version>${version.marshalling}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.marshalling</groupId>
+                <artifactId>jboss-marshalling-serial</artifactId>
+                <version>${version.marshalling}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
 Due to issue #93 when running on a JRE greater than 8 a warning is logged.
 This PR modifies the transitive dependency by Infinispan project on jboss-marshalling.

 These changes remove the osgi project. Which does not have bundled the Multi Release implementations of JDKSpecific$SerMethods. Whereas the api project does.
 Along with the [api](https://github.com/jboss-remoting/jboss-marshalling/blob/2.0.6.Final/osgi/pom.xml#L44) project the [river](https://github.com/jboss-remoting/jboss-marshalling/blob/2.0.6.Final/osgi/pom.xml#L49) and [serial](https://github.com/jboss-remoting/jboss-marshalling/blob/2.0.6.Final/osgi/pom.xml#L54) project need including. To be a complete substitute.

 After the swapping out and testing with the new dependencies the warning message is no longer logged.

 This change removes one obstacle for transitioning to a (future) jre that deprecates reflection.