### PR TITLE
Minor changes to wrk/wk2

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/Wrk.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Wrk.java
@@ -20,7 +20,6 @@
 
 package io.hyperfoil.cli.commands;
 
-import io.hyperfoil.api.config.BenchmarkBuilder;
 import io.hyperfoil.api.config.PhaseBuilder;
 
 import org.aesh.command.CommandDefinition;
@@ -44,8 +43,8 @@ public class Wrk extends WrkAbstract {
    public class WrkCommand extends WrkAbstract.AbstractWrkCommand {
 
       @Override
-      protected PhaseBuilder<?> rootPhase(BenchmarkBuilder benchmarkBuilder, String phase) {
-         return benchmarkBuilder.addPhase(phase).always(threads); //set number of users to number of threads, same threading model as wrk
+      protected PhaseBuilder<?> phaseConfig(PhaseBuilder.Catalog catalog) {
+         return catalog.always(threads).users(threads); //set number of users to number of threads, same threading model as wrk
       }
    }
 

--- a/cli/src/main/java/io/hyperfoil/cli/commands/Wrk2.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Wrk2.java
@@ -20,7 +20,6 @@
 
 package io.hyperfoil.cli.commands;
 
-import io.hyperfoil.api.config.BenchmarkBuilder;
 import io.hyperfoil.api.config.PhaseBuilder;
 
 import org.aesh.command.CommandDefinition;
@@ -48,8 +47,8 @@ public class Wrk2 extends WrkAbstract {
       int rate;
 
       @Override
-      protected PhaseBuilder<?> rootPhase(BenchmarkBuilder benchmarkBuilder, String phase) {
-         return benchmarkBuilder.addPhase(phase).constantPerSec(rate)
+      protected PhaseBuilder<?> phaseConfig(PhaseBuilder.Catalog catalog) {
+         return catalog.constantPerSec(rate)
                .maxSessions(rate * 15);
       }
 


### PR DESCRIPTION
 - Issue with displaying help info defaulting to wrk for wrk and wrk2 command
 - Set default values for connections, duration and threads to values used by original wrk/wrk2
 - Disable periodic throughput statistics written to output buffer. re-enabled via '-p' command option

I have fixed one issue wrt to resolving the correct help info.  The other changes make the commands behaviour like the original wrk and wrk2 commands, so implements the same default values and requires a new cl option '-p' to enable periodic output of throughput during the test phase of the commands