### PR TITLE
maxSequences of instance numbers & DefaultHander for response body

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/config/PhaseBuilder.java
+++ b/api/src/main/java/io/hyperfoil/api/config/PhaseBuilder.java
@@ -38,7 +38,7 @@ public abstract class PhaseBuilder<PB extends PhaseBuilder<PB>> {
 
    public static Phase.Noop noop(SerializableSupplier<Benchmark> benchmark, int id, int iteration, String iterationName, List<String> startAfter, List<String> startAfterStrict, List<String> terminateAfterStrict) {
       FutureSupplier<Phase> ps = new FutureSupplier<>();
-      Scenario scenario = new Scenario(new Sequence[0], new Sequence[0], new String[0], new String[0]);
+      Scenario scenario = new Scenario(new Sequence[0], new Sequence[0], new String[0], new String[0], 0, 0);
       Phase.Noop phase = new Phase.Noop(benchmark, id, iteration, iterationName, startAfter, startAfterStrict, terminateAfterStrict, scenario);
       ps.set(phase);
       return phase;

--- a/api/src/main/java/io/hyperfoil/api/config/Scenario.java
+++ b/api/src/main/java/io/hyperfoil/api/config/Scenario.java
@@ -30,12 +30,16 @@ public class Scenario implements Serializable {
    private final String[] objectVars;
    private final String[] intVars;
    private final Map<String, Sequence> sequenceMap;
+   private int maxRequests;
+   private int maxSequences;
 
-   public Scenario(Sequence[] initialSequences, Sequence[] sequences, String[] objectVars, String[] intVars) {
+   public Scenario(Sequence[] initialSequences, Sequence[] sequences, String[] objectVars, String[] intVars, int maxRequests, int maxSequences) {
       this.initialSequences = initialSequences;
       this.sequences = sequences;
       this.objectVars = objectVars;
       this.intVars = intVars;
+      this.maxRequests = maxRequests;
+      this.maxSequences = maxSequences;
       sequenceMap = Stream.of(sequences).collect(Collectors.toMap(s -> s.name(), Function.identity()));
    }
 
@@ -56,13 +60,11 @@ public class Scenario implements Serializable {
    }
 
    public int maxRequests() {
-      // TODO
-      return 16;
+      return maxRequests;
    }
 
    public int maxSequences() {
-      // TODO
-      return 16;
+      return maxSequences;
    }
 
    public Sequence sequence(String name) {

--- a/api/src/main/java/io/hyperfoil/api/config/ScenarioBuilder.java
+++ b/api/src/main/java/io/hyperfoil/api/config/ScenarioBuilder.java
@@ -37,6 +37,9 @@ public class ScenarioBuilder implements Rewritable<ScenarioBuilder> {
    private Collection<String> objectVars = new ArrayList<>();
    private Collection<String> intVars = new ArrayList<>();
    private Scenario scenario;
+   private int maxRequests = 16;
+   private int maxSequences = 16;
+
 
    ScenarioBuilder(PhaseBuilder<?> phaseBuilder) {
       this.phaseBuilder = phaseBuilder;
@@ -88,6 +91,16 @@ public class ScenarioBuilder implements Rewritable<ScenarioBuilder> {
       return this;
    }
 
+   public ScenarioBuilder maxRequests(int maxRequests) {
+      this.maxRequests = maxRequests;
+      return this;
+   }
+
+   public ScenarioBuilder maxSequences(int maxSequences) {
+      this.maxSequences = maxSequences;
+      return this;
+   }
+
    public void prepareBuild() {
       new ArrayList<>(sequences).forEach(SequenceBuilder::prepareBuild);
    }
@@ -103,7 +116,9 @@ public class ScenarioBuilder implements Rewritable<ScenarioBuilder> {
             initialSequences.stream().map(sequenceBuilder -> sequenceBuilder.build(phase)).toArray(Sequence[]::new),
             sequences.stream().map(sequenceBuilder1 -> sequenceBuilder1.build(phase)).toArray(Sequence[]::new),
             objectVars.toArray(new String[0]),
-            intVars.toArray(new String[0]));
+            intVars.toArray(new String[0]),
+            maxRequests,
+            maxSequences);
    }
 
    @Override

--- a/core/src/main/java/io/hyperfoil/core/parser/ScenarioParser.java
+++ b/core/src/main/java/io/hyperfoil/core/parser/ScenarioParser.java
@@ -31,6 +31,8 @@ class ScenarioParser extends AbstractParser<ScenarioBuilder, ScenarioBuilder> {
       register("orderedSequences", new OrderedSequenceParser());
       register("intVars", new VarParser(ScenarioBuilder::intVar));
       register("objectVars", new VarParser(ScenarioBuilder::objectVar));
+      register("maxSequences", new PropertyParser.Int<>(ScenarioBuilder::maxSequences));
+      register("maxRequests", new PropertyParser.Int<>(ScenarioBuilder::maxRequests));
    }
 
    @Override

--- a/core/src/main/java/io/hyperfoil/core/session/SessionFactory.java
+++ b/core/src/main/java/io/hyperfoil/core/session/SessionFactory.java
@@ -28,7 +28,7 @@ public final class SessionFactory {
    }
 
    public static Session forTesting(Clock clock) {
-      Scenario dummyScenario = new Scenario(new Sequence[0], new Sequence[0], new String[0], new String[0]);
+      Scenario dummyScenario = new Scenario(new Sequence[0], new Sequence[0], new String[0], new String[0], 16, 16);
       SessionImpl session = new SessionImpl(dummyScenario, 0, 0, 0, clock);
       Phase dummyPhase = new Phase(() -> null, 0, 0, "dummy", dummyScenario, 0, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), 0, -1, null) {
          @Override


### PR DESCRIPTION
Please find the update code for maxSequences.  With this code, user is able to set their desired maxSequences number & .  Default is still 16.

Also, requesting to add default handler to allow user to retrieve response body as is.