### PR TITLE
Fix RandomCsvRowStep builderColumns order

### DIFF
--- a/core/src/main/java/io/hyperfoil/core/generators/RandomCsvRowStep.java
+++ b/core/src/main/java/io/hyperfoil/core/generators/RandomCsvRowStep.java
@@ -100,6 +100,9 @@ public class RandomCsvRowStep implements Step, ResourceUtilizer {
             }
          });
          List<String> cols = new ArrayList<>(builderColumns.keySet());
+         for (String key : builderColumns.keySet()) {
+            cols.set(builderColumns.get(key), key);
+         }
 
          Access[] columnVars = cols.stream().map(SessionFactory::access).toArray(Access[]::new);
          return Collections.singletonList(new RandomCsvRowStep(rows.toArray(new String[][]{}), columnVars));


### PR DESCRIPTION
**Version:** 0.9
### **BUG:**
The columns of _randomCsvRow_ step are incorrectly ordered.
**Scenario:**
```yaml
- randomCsvRow:
    file: file.csv
    removeQuotes: true
    skipComments: true
    columns:
      0: first
      1: second
      2: third
      3: fourth
```
**file.csv**
```csv
"0","1","2","3"
```
**Logs from the run:**
```logs
14:32:41,666 TRACE [io.hyperfoil.core.session.SessionImpl] (nioEventLoopGroup-2-1) #0 third <- 0
14:32:41,666 TRACE [io.hyperfoil.core.session.SessionImpl] (nioEventLoopGroup-2-1) #0 fourth <- 1
14:32:41,666 TRACE [io.hyperfoil.core.session.SessionImpl] (nioEventLoopGroup-2-1) #0 first <- 2
14:32:41,666 TRACE [io.hyperfoil.core.session.SessionImpl] (nioEventLoopGroup-2-1) #0 second <- 3
```
### Problem
```java
List<String> cols = new ArrayList<>(builderColumns.keySet());
```
`builderColumns.keySet()` returns `Set` which means the order of columns is lost.

### Proposed solution
Set each `columnVar` to its position in the `cols` array.

I was able to reproduce it also on 0.10-SNAPSHOT version (quay.io/hyperfoil/hyperfoil:0.10-SNAPSHOT).
I wasn't able to write a unit test for this kind of issue. I would like to add a simple example.

```java
Map<String, Integer> builderColumns = new HashMap<>();
        builderColumns.put("first",0);
        builderColumns.put("second",1);
        builderColumns.put("third",2);
        builderColumns.put("fourth",3);
        System.out.println(builderColumns.keySet());

        List<String> cols = new ArrayList<>(builderColumns.keySet());
        for (String key : builderColumns.keySet()) {
            cols.set(builderColumns.get(key), key);
        }
        System.out.println(cols);
```
Returns:
```
[third, fourth, first, second]
[first, second, third, fourth]
```