### PR TITLE
Fix Illegal reflective access LongFastUUID

### DIFF
--- a/distribution/src/main/resources/parse-opts.sh
+++ b/distribution/src/main/resources/parse-opts.sh
@@ -29,6 +29,7 @@ fi
 ROOT=$(dirname $0)/..
 CP=$(find $ROOT/lib $ROOT/extensions | tr '\n' ':')
 JAVA_OPTS="$JAVA_OPTS \
+   --add-opens java.base/java.lang=ALL-UNNAMED \
    -Djava.net.preferIPv4Stack=true \
    -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory"
 

--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,7 @@
                         <systemPropertyVariables>
                             <vertx.logger-delegate-factory-class-name>io.vertx.core.logging.Log4j2LogDelegateFactory</vertx.logger-delegate-factory-class-name>
                         </systemPropertyVariables>
+                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
Tested with
```
openjdk version "17-ea" 2021-09-14
OpenJDK Runtime Environment (build 17-ea+12-906)
OpenJDK 64-Bit Server VM (build 17-ea+12-906, mixed mode, sharing)

```