### PR TITLE
Display user friendly exception message when selecting random item from empty collection

### DIFF
--- a/core/src/main/java/io/hyperfoil/core/generators/RandomItemStep.java
+++ b/core/src/main/java/io/hyperfoil/core/generators/RandomItemStep.java
@@ -61,7 +61,11 @@ public class RandomItemStep implements Step, ResourceUtilizer {
                   break;
                }
             }
-            element = array[random.nextInt(length)];
+            if (length > 0) {
+               element = array[random.nextInt(length)];
+            } else {
+               throw new IllegalStateException("Collection " + fromVar + " is empty, can not select a random item");
+            }
          } else if (data != null && data.getClass().isArray()) {
             int length = Array.getLength(data);
             element = Array.get(data, random.nextInt(length));


### PR DESCRIPTION
Log a more user friendly exception message when `randomItem` tries to select from an empty collection;

message has changed from 
```
java.lang.IllegalStateException: bound must be positive
```

to

```
java.lang.IllegalStateException: Collection items is empty, can not select a random item
```