### PR TITLE
Consistently allow overriding using environment variables

### DIFF
--- a/k8s-deployer/src/main/java/io/hyperfoil/deploy/k8s/K8sDeployer.java
+++ b/k8s-deployer/src/main/java/io/hyperfoil/deploy/k8s/K8sDeployer.java
@@ -82,12 +82,12 @@ public class K8sDeployer implements Deployer {
    private KubernetesClient client;
 
    static {
-      APP = System.getProperty("io.hyperfoil.deployer.k8s.app");
+      APP = Properties.get("io.hyperfoil.deployer.k8s.app", null);
       NAMESPACE = getPropertyOrLoad("io.hyperfoil.deployer.k8s.namespace", "namespace");
    }
 
    private static String getPropertyOrLoad(String property, String file) {
-      String value = System.getProperty(property);
+      String value = Properties.get(property, null);
       if (value != null) {
          return value;
       }


### PR DESCRIPTION
It can be tricky to inject values from a configmap into a system property. easier to inject as an env var, so allowing overrides to always work from an env var improves consistency