### PR TITLE
Fix case where scheme does not start with `file:`

### DIFF
--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerServer.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerServer.java
@@ -297,7 +297,7 @@ class ControllerServer implements ApiService {
          ctx.response().setStatusCode(HttpResponseStatus.BAD_REQUEST.code()).end(uri.getScheme() + " scheme URIs are not supported.");
          return;
       }
-      var localPath = Paths.get(uri).toAbsolutePath();
+      var localPath = (uri.getScheme() == null ? Paths.get(uri.getPath()) : Paths.get(uri)).toAbsolutePath();
       if (!localPath.startsWith(loadDirPath) || !Files.isRegularFile(localPath)) {
          log.error("Unknown controller local benchmark {}.", localPath);
          ctx.response().setStatusCode(HttpResponseStatus.BAD_REQUEST.code()).end("Unknown controller local benchmark.");


### PR DESCRIPTION
Who knew Paths.get(URI) mandates a scheme!