### PR TITLE
Bump Vert.x to 4.3.0 and use infinispan version 13

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -62,6 +62,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.hyperfoil</groupId>
             <artifactId>hyperfoil-core</artifactId>
         </dependency>

--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -50,6 +50,14 @@
                     <groupId>org.jboss.marshalling</groupId>
                     <artifactId>jboss-marshalling-osgi</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.wildfly.common</groupId>
+                    <artifactId>wildfly-common</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -51,12 +51,8 @@
                     <artifactId>jboss-marshalling-osgi</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.wildfly.common</groupId>
-                    <artifactId>wildfly-common</artifactId>
+                    <groupId>org.jboss.threads</groupId>
+                    <artifactId>jboss-threads</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -64,7 +60,11 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
         </dependency>
 
         <dependency>
@@ -133,6 +133,11 @@
             for >8 jre -->
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-serial</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.threads</groupId>
+            <artifactId>jboss-threads</artifactId>
         </dependency>
     </dependencies>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <module.skipCopyDependencies>true</module.skipCopyDependencies>
+        <container.registry.repository>quay.io/hyperfoil</container.registry.repository>
     </properties>
 
     <dependencies>
@@ -320,7 +321,7 @@
                             </access>
                             <images>
                                 <image>
-                                    <name>quay.io/hyperfoil/hyperfoil:${project.version}</name>
+                                    <name>${container.registry.repository}/hyperfoil:${project.version}</name>
                                     <build>
                                         <contextDir>${project.basedir}/src/main/docker/</contextDir>
                                         <tags>

--- a/hotrod/pom.xml
+++ b/hotrod/pom.xml
@@ -23,7 +23,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.4.3.Final</version>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -199,6 +198,7 @@
                                     <include>org.infinispan.protostream:*</include>
                                     <include>org.wildfly.common:*</include>
                                     <include>org.wildfly.security:*</include>
+                                    <include>org.jboss.logging:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/hotrod/pom.xml
+++ b/hotrod/pom.xml
@@ -198,7 +198,6 @@
                                     <include>org.infinispan.protostream:*</include>
                                     <include>org.wildfly.common:*</include>
                                     <include>org.wildfly.security:*</include>
-                                    <include>org.jboss.logging:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/hotrod/pom.xml
+++ b/hotrod/pom.xml
@@ -11,7 +11,7 @@
     <name>Hyperfoil Hot Rod Client</name>
 
     <properties>
-        <version.infinispan>12.1.0.CR1</version.infinispan>
+        <version.infinispan>13.0.8.Final</version.infinispan>
     </properties>
 
     <dependencies>

--- a/hotrod/pom.xml
+++ b/hotrod/pom.xml
@@ -21,9 +21,36 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.4.3.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
             <version>${version.infinispan}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.sshd</groupId>
+                    <artifactId>sshd-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.reactivex.rxjava3</groupId>
+                    <artifactId>rxjava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.reactivex.rxjava2</groupId>
+                    <artifactId>rxjava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -47,6 +74,12 @@
             <artifactId>infinispan-server-hotrod</artifactId>
             <version>${version.infinispan}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -61,12 +94,29 @@
             <version>${version.infinispan}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
             <version>${version.infinispan}</version>
+            <scope>test</scope>
             <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.wildfly.common</groupId>
+                    <artifactId>wildfly-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -74,12 +124,32 @@
             <version>${version.infinispan}</version>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons-test</artifactId>
             <version>${version.infinispan}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.reactivex.rxjava3</groupId>
+                    <artifactId>rxjava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.reactivex.rxjava2</groupId>
+                    <artifactId>rxjava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/hotrod/pom.xml
+++ b/hotrod/pom.xml
@@ -182,6 +182,15 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <!-- The output jar contains shaded resources as well, and shade would try to combine
+                         this module's JAR with the shaded dependencies and error due to duplicates. -->
+                    <forceCreation>true</forceCreation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
                 <executions>

--- a/hotrod/pom.xml
+++ b/hotrod/pom.xml
@@ -10,10 +10,6 @@
     <artifactId>hyperfoil-hotrod</artifactId>
     <name>Hyperfoil Hot Rod Client</name>
 
-    <properties>
-        <version.infinispan>13.0.8.Final</version.infinispan>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.hyperfoil</groupId>
@@ -65,6 +61,12 @@
             <version>${version.infinispan}</version>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <version>${version.infinispan}</version>
+            <type>test-jar</type>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>

--- a/k8s-deployer/pom.xml
+++ b/k8s-deployer/pom.xml
@@ -21,6 +21,12 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.activation</groupId>
+                    <artifactId>jakarta.activation-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugins/codegen/pom.xml
+++ b/plugins/codegen/pom.xml
@@ -21,17 +21,43 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -40,17 +40,43 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-component-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.maven</groupId>
+                    <artifactId>maven-artifact</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <version.slf4j>1.7.32</version.slf4j>
         <version.snakeyaml>1.26</version.snakeyaml>
         <version.vertx>4.3.0</version.vertx>
+        <version.infinispan>13.0.8.Final</version.infinispan>
 
         <version.sonatype.nexus>1.6.8</version.sonatype.nexus>
         <version.maven.source>3.0.1</version.maven.source>
@@ -263,6 +264,12 @@
                 <version>${version.vertx}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-core</artifactId>
+                <version>${version.infinispan}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <version.javaparser>3.14.12</version.javaparser>
         <version.jackson>2.11.3</version.jackson>
         <version.marshalling>2.0.6.Final</version.marshalling>
+        <version.logging>3.4.3.Final</version.logging>
         <version.junit>4.13.1</version.junit>
         <version.log4j2>2.17.1</version.log4j2>
         <version.metainf-services>1.8</version.metainf-services>
@@ -384,6 +385,12 @@
                 <groupId>org.jboss.marshalling</groupId>
                 <artifactId>jboss-marshalling-serial</artifactId>
                 <version>${version.marshalling}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${version.logging}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,6 @@
         <version.javaparser>3.14.12</version.javaparser>
         <version.jackson>2.11.3</version.jackson>
         <version.marshalling>2.0.6.Final</version.marshalling>
-        <version.logging>3.4.3.Final</version.logging>
         <version.junit>4.13.1</version.junit>
         <version.log4j2>2.17.1</version.log4j2>
         <version.metainf-services>1.8</version.metainf-services>
@@ -98,6 +97,9 @@
         <version.snakeyaml>1.26</version.snakeyaml>
         <version.vertx>4.3.0</version.vertx>
         <version.infinispan>13.0.8.Final</version.infinispan>
+        <version.jboss-threads>3.4.2.Final</version.jboss-threads>
+        <version.jboss-logging>3.4.1.Final</version.jboss-logging>
+        <version.wildfly-common>1.5.4.Final</version.wildfly-common>
 
         <version.sonatype.nexus>1.6.8</version.sonatype.nexus>
         <version.maven.source>3.0.1</version.maven.source>
@@ -388,9 +390,27 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.threads</groupId>
+                <artifactId>jboss-threads</artifactId>
+                <version>${version.jboss-threads}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wildfly.common</groupId>
+                        <artifactId>wildfly-common</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
-                <version>${version.logging}</version>
+                <version>${version.jboss-logging}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.common</groupId>
+                <artifactId>wildfly-common</artifactId>
+                <version>${version.wildfly-common}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,29 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                                <requireReleaseDeps>
+                                    <excludes>io.hyperfoil:*</excludes>
+                                    <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+                                </requireReleaseDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <inherited>false</inherited>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <version.netty.tcnative.boringssl>2.0.42.Final</version.netty.tcnative.boringssl>
         <version.slf4j>1.7.32</version.slf4j>
         <version.snakeyaml>1.26</version.snakeyaml>
-        <version.vertx>4.1.3</version.vertx>
+        <version.vertx>4.3.0</version.vertx>
 
         <version.sonatype.nexus>1.6.8</version.sonatype.nexus>
         <version.maven.source>3.0.1</version.maven.source>


### PR DESCRIPTION
I'm running into https://issues.redhat.com/browse/ISPN-13231 that is
fixed in version 13, see @rvansa's comment in
https://github.com/openshift-knative/eventing-hyperfoil-benchmark/issues/44#issuecomment-1125892802.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>