### PR TITLE
No connection pool when authority and host are both defined without port

### DIFF
--- a/http/src/main/java/io/hyperfoil/http/config/HttpBuilder.java
+++ b/http/src/main/java/io/hyperfoil/http/config/HttpBuilder.java
@@ -79,8 +79,10 @@ public class HttpBuilder implements BuilderBase<HttpBuilder> {
    String authority() {
       if (host() == null) {
          return null;
+      } else if (port == -1) {
+         return host();
       } else {
-         return host() + ":" + port();
+         return host() + ":" + portOrDefault();
       }
    }
 
@@ -100,7 +102,7 @@ public class HttpBuilder implements BuilderBase<HttpBuilder> {
       return host;
    }
 
-   public int port() {
+   public int portOrDefault() {
       if (port != -1) {
          return port;
       } else if (protocol != null) {

--- a/http/src/main/java/io/hyperfoil/http/config/HttpPluginBuilder.java
+++ b/http/src/main/java/io/hyperfoil/http/config/HttpPluginBuilder.java
@@ -109,7 +109,7 @@ public class HttpPluginBuilder extends PluginBuilder<HttpErgonomics> {
    private boolean isValidAuthority(String authority) {
       long matches = httpList.stream()
             .filter(distinctByKey(http -> http.protocol() + http.authority())) // skip potential duplicate authorities
-            .filter(http -> http.authority().contains(authority))
+            .filter(http -> compareAuthorities(http, authority))
             .count();
       return matches == 1; // only one authority should match
    }
@@ -117,6 +117,17 @@ public class HttpPluginBuilder extends PluginBuilder<HttpErgonomics> {
    private static <T> Predicate<T> distinctByKey(Function<? super T, Object> keyExtractor) {
       Map<Object, Boolean> map = new ConcurrentHashMap<>();
       return t -> map.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
+   }
+
+   private static boolean compareAuthorities(HttpBuilder http, String authority) {
+      final StringBuilder auth1 = new StringBuilder(http.authority()), auth2 = new StringBuilder(authority);
+      if (!http.authority().contains(":")) {
+         auth1.append(":").append(http.portOrDefault());
+      }
+      if (!authority.contains(":")) {
+         auth2.append(":").append(http.portOrDefault());
+      }
+      return auth1.toString().equals(auth2.toString());
    }
 
    public boolean validateEndpoint(String endpoint) {


### PR DESCRIPTION
Due to https://github.com/Hyperfoil/Hyperfoil/pull/245, running a benchmark fails at runtime when authority and host are defined without any port, as it complains that no authority is defined for a particular host