### PR TITLE
Improved HTTP 1x decoding

### DIFF
--- a/http/src/test/java/io/hyperfoil/http/HttpClientPoolHandlerTest.java
+++ b/http/src/test/java/io/hyperfoil/http/HttpClientPoolHandlerTest.java
@@ -95,8 +95,8 @@ public class HttpClientPoolHandlerTest {
                   latch.countDown();
                })
                .header((req, header, value) -> {
-                  if ("foo".equals(header)) {
-                     assertThat(value).isEqualTo("bar");
+                  if ("foo".contentEquals(header)) {
+                     assertThat("bar").asString().isEqualTo("bar");
                      latch.countDown();
                   }
                })


### PR DESCRIPTION
Still draft given that's WIP; already opened to suggestions/questions/crititics

General description is:
1. `readHeaders` often pop up on cpu profiling sessions due to highly variable line length, causing bad misprediction(s) of parser/decoder next state, while reading byte-per-byte incoming data
2. `readHeaders`  contains `byte[]/String` heavy allocators (for header names/values)

The first has been solved by using https://github.com/netty/netty/pull/10737 I've introduced some time ago in Netty (and that show larger benefits as the number of bytes processed grows and when inputs sequences makes branch predictions useless), that's still better then any `ByteBuf::getByte`, which perform accessibility/refCnt and bound checks per-call, while `indexOf` perfom it just once.

The second has been solved by using already "latin" encoded strings available in Netty ie `AsciiString` which allows:
- saving an intermediate `byte[]` buffer to be used to create the `String`
- optimized `AsciiString::contentEqualsIgnoreCase` eg used on `HttpCacheImpl::responseHeader`,`HttpResponseHandlersImpl::handleHeader`
- optimized accesses by reaching the internal byte[], if necessary (for further improvements)

Some potential drawbacks of using `AsciiString` is that we won't have any JVM intrinsics available on it for some specific methods

