### PR TITLE
Reducing type check ping-pong

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/session/Session.java
+++ b/api/src/main/java/io/hyperfoil/api/session/Session.java
@@ -1,7 +1,6 @@
 package io.hyperfoil.api.session;
 
 import java.io.Serializable;
-import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 
 import io.hyperfoil.api.config.Scenario;
@@ -11,7 +10,9 @@ import io.netty.util.concurrent.EventExecutor;
 import io.hyperfoil.api.statistics.Statistics;
 import io.hyperfoil.api.config.Phase;
 
-public interface Session extends Callable<Void> {
+public interface Session {
+
+   Runnable runTask();
 
    void reserve(Scenario scenario);
 

--- a/core/src/main/java/io/hyperfoil/core/steps/DelaySessionStartStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/DelaySessionStartStep.java
@@ -51,7 +51,7 @@ public class DelaySessionStartStep implements Step, ResourceUtilizer {
       if (now < next) {
          if (holder.future == null) {
             log.trace("#{} scheduling in {} ms", session.uniqueId(), next - now);
-            holder.future = session.executor().schedule(session, next - now, TimeUnit.MILLISECONDS);
+            holder.future = session.executor().schedule(session.runTask(), next - now, TimeUnit.MILLISECONDS);
          }
          return false;
       }
@@ -72,7 +72,7 @@ public class DelaySessionStartStep implements Step, ResourceUtilizer {
       public int iteration = 0;
       public long startTimeWithOffset = Long.MIN_VALUE;
       public double period;
-      public ScheduledFuture<Void> future;
+      public ScheduledFuture<?> future;
       public PhaseInstance phase;
 
       public long lastStartTime() {

--- a/core/src/main/java/io/hyperfoil/core/steps/PollStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/PollStep.java
@@ -45,7 +45,7 @@ public class PollStep<T> implements Step {
          if (object == null) {
             // Note: it's possible that we'll try to poll earlier
             log.trace("Did not fetch object, scheduling #{} in {}", session.uniqueId(), periodMs);
-            session.executor().schedule(session, periodMs, TimeUnit.MILLISECONDS);
+            session.executor().schedule(session.runTask(), periodMs, TimeUnit.MILLISECONDS);
             return false;
          } else if (filter.test(session, object)) {
             toVar.setObject(session, object);
@@ -56,7 +56,7 @@ public class PollStep<T> implements Step {
       }
       // We did not have an accepting match
       log.trace("Not accepted, scheduling #{} in {}", session.uniqueId(), periodMs);
-      session.executor().schedule(session, periodMs, TimeUnit.MILLISECONDS);
+      session.executor().schedule(session.runTask(), periodMs, TimeUnit.MILLISECONDS);
       return false;
    }
 

--- a/core/src/main/java/io/hyperfoil/core/steps/ScheduleDelayStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/ScheduleDelayStep.java
@@ -63,7 +63,7 @@ public class ScheduleDelayStep implements Step, ResourceUtilizer {
       long delay = blockedUntil.timestamp - now;
       if (delay > 0) {
          log.trace("Scheduling #{} to run in {}", session.uniqueId(), delay);
-         session.executor().schedule(session, delay, TimeUnit.MILLISECONDS);
+         session.executor().schedule(session.runTask(), delay, TimeUnit.MILLISECONDS);
       } else {
          log.trace("Continuing, duration {} resulted in delay {}", duration, delay);
       }


### PR DESCRIPTION
These are the noteworthy type check ping-pong happening in the hot path and affecting scalability:
```
--------------------------
Type Pollution Statistics:
--------------------------
Date:   2023/04/13 16:53:02
Last:   true
--------------------------
1:      io.hyperfoil.http.HttpCacheImpl
Count:  25824949
Types:
        io.hyperfoil.api.session.Session$Resource
        io.hyperfoil.http.api.HttpCache
Traces:
        io.hyperfoil.http.api.HttpCache.get(HttpCache.java:28)
                class: io.hyperfoil.http.api.HttpCache
                count: 12900860
        io.hyperfoil.core.session.SessionImpl.getResource(SessionImpl.java:206)
                class: io.hyperfoil.api.session.Session$Resource
                count: 11015844
        io.hyperfoil.core.session.SessionImpl.reset(SessionImpl.java:459)
                class: io.hyperfoil.api.session.Session$Resource
                count: 1908245
--------------------------
2:      io.netty.util.concurrent.PromiseTask
Count:  14431885
Types:
        java.lang.Runnable
        io.netty.util.concurrent.Future
Traces:
        io.netty.util.concurrent.SingleThreadEventExecutor.pollTaskFrom(SingleThreadEventExecutor.java:216)
                class: java.lang.Runnable
                count: 7221173
        io.netty.util.concurrent.AbstractEventExecutor.submit(AbstractEventExecutor.java:128)
                class: io.netty.util.concurrent.Future
                count: 7210712
--------------------------
3:      io.hyperfoil.http.connection.HttpDestinationTableImpl
Count:  6543393
Types:
        io.hyperfoil.api.session.Session$Resource
        io.hyperfoil.http.api.HttpDestinationTable
Traces:
        io.hyperfoil.http.api.HttpDestinationTable.get(HttpDestinationTable.java:22)
                class: io.hyperfoil.http.api.HttpDestinationTable
                count: 3271574
        io.hyperfoil.core.session.SessionImpl.reset(SessionImpl.java:459)
                class: io.hyperfoil.api.session.Session$Resource
                count: 1797027
        io.hyperfoil.core.session.SessionImpl.getResource(SessionImpl.java:206)
                class: io.hyperfoil.api.session.Session$Resource
                count: 1474792
--------------------------
4:      io.hyperfoil.core.session.SessionImpl
Count:  4434790
Types:
        java.util.concurrent.Callable
        io.hyperfoil.api.session.Session
Traces:
        io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:95)
                class: java.util.concurrent.Callable
                count: 2211230
        io.hyperfoil.http.api.HttpMethod$Provided.apply(HttpMethod.java:40)
                class: io.hyperfoil.api.session.Session
                count: 2209823
        io.hyperfoil.core.generators.Pattern.apply(Pattern.java:28)
                class: io.hyperfoil.api.session.Session
                count: 6985
        io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:96)
                class: java.util.concurrent.Callable
                count: 6750
        io.hyperfoil.core.impl.SimulationRunner.shutdown(SimulationRunner.java:269)
                class: io.hyperfoil.api.session.Session
                count: 1
        io.hyperfoil.core.impl.PhaseInstanceImpl.startNewSession(PhaseInstanceImpl.java:243)
                class: io.hyperfoil.api.session.Session
                count: 1
--------------------------
```
After this PR they are now:
```
--------------------------
Type Pollution Statistics:
--------------------------
Date:   2023/04/13 18:03:02
Last:   true
--------------------------
1:      io.hyperfoil.http.HttpCacheImpl
Count:  27496824
Types:
        io.hyperfoil.api.session.Session$Resource
        io.hyperfoil.http.api.HttpCache
Traces:
        io.hyperfoil.http.api.HttpCache.get(HttpCache.java:28)
                class: io.hyperfoil.http.api.HttpCache
                count: 13723490
        io.hyperfoil.core.session.SessionImpl.getResource(SessionImpl.java:212)
                class: io.hyperfoil.api.session.Session$Resource
                count: 11584452
        io.hyperfoil.core.session.SessionImpl.reset(SessionImpl.java:463)
                class: io.hyperfoil.api.session.Session$Resource
                count: 2188882
--------------------------
2:      io.hyperfoil.http.connection.HttpDestinationTableImpl
Count:  7019394
Types:
        io.hyperfoil.api.session.Session$Resource
        io.hyperfoil.http.api.HttpDestinationTable
Traces:
        io.hyperfoil.http.api.HttpDestinationTable.get(HttpDestinationTable.java:22)
                class: io.hyperfoil.http.api.HttpDestinationTable
                count: 3509283
        io.hyperfoil.core.session.SessionImpl.reset(SessionImpl.java:463)
                class: io.hyperfoil.api.session.Session$Resource
                count: 2164796
        io.hyperfoil.core.session.SessionImpl.getResource(SessionImpl.java:212)
                class: io.hyperfoil.api.session.Session$Resource
                count: 1345315
--------------------------
```
I've eliminated the ones on `io.netty.util.concurrent.PromiseTask` and `io.hyperfoil.core.session.SessionImpl`.
The other ones could be (I have to verify it TBH) false positives., but still, better be safe...