### PR TITLE
Additional startWith with delay feature

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/config/PhaseReferenceDelay.java
+++ b/api/src/main/java/io/hyperfoil/api/config/PhaseReferenceDelay.java
@@ -1,0 +1,10 @@
+package io.hyperfoil.api.config;
+
+public class PhaseReferenceDelay extends PhaseReference {
+   public final long delay;
+
+   public PhaseReferenceDelay(String phase, RelativeIteration iteration, String fork, long delay) {
+      super(phase, iteration, fork);
+      this.delay = delay;
+   }
+}

--- a/api/src/main/java/io/hyperfoil/api/config/StartWithDelay.java
+++ b/api/src/main/java/io/hyperfoil/api/config/StartWithDelay.java
@@ -1,0 +1,13 @@
+package io.hyperfoil.api.config;
+
+import java.io.Serializable;
+
+public class StartWithDelay implements Serializable {
+   public final String phase;
+   public final long delay;
+
+   public StartWithDelay(String phase, long delay) {
+      this.phase = phase;
+      this.delay = delay;
+   }
+}

--- a/api/src/main/java/io/hyperfoil/api/session/PhaseInstance.java
+++ b/api/src/main/java/io/hyperfoil/api/session/PhaseInstance.java
@@ -65,5 +65,9 @@ public interface PhaseInstance {
       public boolean isTerminated() {
          return this.ordinal() >= TERMINATED.ordinal();
       }
+
+      public boolean isStarted() {
+         return this.ordinal() >= RUNNING.ordinal();
+      }
    }
 }

--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerPhase.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerPhase.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 
 public class ControllerPhase {
-   private static Logger log = LogManager.getLogger(ControllerPhase.class);
+   private static final Logger log = LogManager.getLogger(ControllerPhase.class);
 
    private final Phase definition;
    private Status status = Status.NOT_STARTED;
@@ -106,6 +106,10 @@ public class ControllerPhase {
 
       public boolean isTerminated() {
          return ordinal() >= TERMINATED.ordinal();
+      }
+
+      public boolean isStarted() {
+         return ordinal() >= RUNNING.ordinal();
       }
    }
 }

--- a/clustering/src/main/java/io/hyperfoil/clustering/Run.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/Run.java
@@ -68,7 +68,10 @@ class Run {
       return phases.values().stream().filter(phase -> phase.status() == ControllerPhase.Status.NOT_STARTED &&
             startTime + phase.definition().startTime() <= System.currentTimeMillis() &&
             phase.definition().startAfter().stream().allMatch(dep -> phases.get(dep).status().isFinished()) &&
-            phase.definition().startAfterStrict().stream().allMatch(dep -> phases.get(dep).status().isTerminated()))
+            phase.definition().startAfterStrict().stream().allMatch(dep -> phases.get(dep).status().isTerminated()) &&
+            (phase.definition().startWithDelay() == null ||
+                  phases.get(phase.definition().startWithDelay().phase).status().isStarted() &&
+                  phases.get(phase.definition().startWithDelay().phase).absoluteStartTime() + phase.definition().startWithDelay().delay <= System.currentTimeMillis()))
             .toArray(ControllerPhase[]::new);
    }
 

--- a/core/src/main/java/io/hyperfoil/core/impl/LocalSimulationRunner.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/LocalSimulationRunner.java
@@ -1,5 +1,6 @@
 package io.hyperfoil.core.impl;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -149,7 +150,18 @@ public class LocalSimulationRunner extends SimulationRunner {
       return instances.values().stream().filter(phase -> phase.status() == PhaseInstance.Status.NOT_STARTED &&
             startTime + phase.definition().startTime() <= System.currentTimeMillis() &&
             phase.definition().startAfter().stream().allMatch(dep -> instances.get(dep).status().isFinished()) &&
-            phase.definition().startAfterStrict().stream().allMatch(dep -> instances.get(dep).status().isTerminated()))
+            phase.definition().startAfterStrict().stream().allMatch(dep -> instances.get(dep).status().isTerminated()) &&
+            (phase.definition().startWithDelay() == null ||
+                  instances.get(phase.definition().startWithDelay().phase).status().isStarted() &&
+                  instances.get(phase.definition().startWithDelay().phase).absoluteStartTime() + phase.definition().startWithDelay().delay <= System.currentTimeMillis()))
             .toArray(PhaseInstance[]::new);
+   }
+
+   /**
+    * More for testing purposes, allow internal phases inspection
+    * @return the phase instances map
+    */
+   public Map<String, PhaseInstance> instances() {
+      return instances;
    }
 }

--- a/core/src/main/java/io/hyperfoil/core/parser/PhaseParser.java
+++ b/core/src/main/java/io/hyperfoil/core/parser/PhaseParser.java
@@ -24,6 +24,7 @@ abstract class PhaseParser extends AbstractParser<PhaseBuilder.Catalog, PhaseBui
       register("maxIterations", new PropertyParser.Int<>(PhaseBuilder::maxIterations));
       register("isWarmup", new PropertyParser.Boolean<>(PhaseBuilder::isWarmup));
       register("customSla", new CustomSLAParser());
+      register("startWith", new StartWithParser(PhaseBuilder::startWith));
    }
 
    @Override

--- a/core/src/main/java/io/hyperfoil/core/parser/StartWithParser.java
+++ b/core/src/main/java/io/hyperfoil/core/parser/StartWithParser.java
@@ -1,0 +1,61 @@
+package io.hyperfoil.core.parser;
+
+import java.util.function.BiConsumer;
+
+import org.yaml.snakeyaml.events.Event;
+import org.yaml.snakeyaml.events.MappingStartEvent;
+import org.yaml.snakeyaml.events.ScalarEvent;
+import org.yaml.snakeyaml.events.SequenceStartEvent;
+
+import io.hyperfoil.api.config.BenchmarkDefinitionException;
+import io.hyperfoil.api.config.PhaseBuilder;
+import io.hyperfoil.api.config.RelativeIteration;
+import io.hyperfoil.api.config.PhaseReferenceDelay;
+import io.hyperfoil.impl.Util;
+
+class StartWithParser implements Parser<PhaseBuilder<?>> {
+   private final BiConsumer<PhaseBuilder<?>, PhaseReferenceDelay> consumer;
+
+   StartWithParser(BiConsumer<PhaseBuilder<?>, PhaseReferenceDelay> consumer) {
+      this.consumer = consumer;
+   }
+
+   @Override
+   public void parse(Context ctx, PhaseBuilder<?> target) throws ParserException {
+      if (!ctx.hasNext()) {
+         throw ctx.noMoreEvents(ScalarEvent.class, SequenceStartEvent.class, MappingStartEvent.class);
+      }
+      Event event = ctx.peek();
+      if (event instanceof ScalarEvent) {
+         consumer.accept(target, new PhaseReferenceDelay(((ScalarEvent) event).getValue(), RelativeIteration.NONE, null, 0));
+         ctx.consumePeeked(event);
+      } else if (event instanceof MappingStartEvent) {
+         StartWithBuilder swb = new StartWithBuilder();
+         MappingParser.INSTANCE.parse(ctx, swb);
+         if (swb.phase == null || swb.phase.isEmpty()) {
+            throw new BenchmarkDefinitionException("Missing name in phase reference.");
+         }
+         consumer.accept(target, new PhaseReferenceDelay(swb.phase, swb.iteration, swb.fork, swb.delay));
+      } else {
+         throw ctx.unexpectedEvent(event);
+      }
+   }
+
+   private static class StartWithBuilder {
+      String phase;
+      RelativeIteration iteration = RelativeIteration.NONE;
+      String fork;
+      long delay;
+   }
+
+   private static class MappingParser extends AbstractMappingParser<StartWithBuilder> {
+      static MappingParser INSTANCE = new MappingParser();
+
+      MappingParser() {
+         register("phase", new PropertyParser.String<>((b, value) -> b.phase = value));
+         register("iteration", new PropertyParser.String<>((b, value) -> b.iteration = RelativeIteration.valueOf(value.toUpperCase())));
+         register("fork", new PropertyParser.String<>((b, value) -> b.fork = value));
+         register("delay", new PropertyParser.String<>((b, value) -> b.delay = Util.parseToMillis(value)));
+      }
+   }
+}

--- a/core/src/main/java/io/hyperfoil/core/session/SessionFactory.java
+++ b/core/src/main/java/io/hyperfoil/core/session/SessionFactory.java
@@ -11,8 +11,8 @@ import io.hyperfoil.api.config.Phase;
 import io.hyperfoil.api.config.Scenario;
 import io.hyperfoil.api.config.Sequence;
 import io.hyperfoil.api.config.Step;
-import io.hyperfoil.api.session.ObjectAccess;
 import io.hyperfoil.api.session.IntAccess;
+import io.hyperfoil.api.session.ObjectAccess;
 import io.hyperfoil.api.session.ReadAccess;
 import io.hyperfoil.api.session.Session;
 import io.hyperfoil.api.session.WriteAccess;
@@ -49,7 +49,7 @@ public final class SessionFactory {
       }, 16, 16);
       SessionImpl session = new SessionImpl(dummyScenario, 0, 0);
       Phase dummyPhase = new Phase(Benchmark::forTesting, 0, 0, "dummy", dummyScenario, 0,
-            Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), 0, -1, null, false, () -> "dummy", Collections.emptyMap());
+            Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), 0, -1, null, false, () -> "dummy", Collections.emptyMap(), null);
       session.resetPhase(new PhaseInstanceImpl(dummyPhase, "dummy", 0) {
          @Override
          public void proceed(EventExecutorGroup executorGroup) {

--- a/core/src/test/java/io/hyperfoil/core/builder/InvalidBenchmarkTest.java
+++ b/core/src/test/java/io/hyperfoil/core/builder/InvalidBenchmarkTest.java
@@ -6,6 +6,8 @@ import org.junit.rules.ExpectedException;
 
 import io.hyperfoil.api.config.BenchmarkBuilder;
 import io.hyperfoil.api.config.PhaseBuilder;
+import io.hyperfoil.api.config.RelativeIteration;
+import io.hyperfoil.api.config.PhaseReferenceDelay;
 import io.hyperfoil.core.builders.StepCatalog;
 
 public class InvalidBenchmarkTest {
@@ -37,6 +39,61 @@ public class InvalidBenchmarkTest {
       BenchmarkBuilder builder = BenchmarkBuilder.builder();
       builder.addPhase("test").atOnce(1).scenario().initialSequence("test")
             .step(StepCatalog.SC).log("Blabla: ${foo}");
+      builder.build();
+   }
+
+   @Test
+   public void testMissingPhaseOnStartWith() {
+      thrown.expectMessage(" is not defined");
+      BenchmarkBuilder builder = BenchmarkBuilder.builder();
+      initPhase(builder.addPhase("foo").always(1).startWith(new PhaseReferenceDelay("bar", RelativeIteration.NONE, null, 10)));
+      builder.build();
+   }
+
+   @Test
+   public void testSimultaneousStartAfterAndStartWith() {
+      thrown.expectMessage("has both startWith and one of startAfter, startAfterStrict and startTime set.");
+      BenchmarkBuilder builder = BenchmarkBuilder.builder();
+      initPhase(builder.addPhase("foo").always(1).startAfter("bar").startWith("bar"));
+      initPhase(builder.addPhase("bar").always(1));
+      builder.build();
+   }
+
+   @Test
+   public void testSimultaneousStartAfterStrictAndStartWith() {
+      thrown.expectMessage("has both startWith and one of startAfter, startAfterStrict and startTime set.");
+      BenchmarkBuilder builder = BenchmarkBuilder.builder();
+      initPhase(builder.addPhase("foo").always(1).startAfterStrict("bar").startWith("bar"));
+      initPhase(builder.addPhase("bar").always(1));
+      builder.build();
+   }
+
+   @Test
+   public void testSimultaneousStartTimeAndStartWith() {
+      thrown.expectMessage("has both startWith and one of startAfter, startAfterStrict and startTime set.");
+      BenchmarkBuilder builder = BenchmarkBuilder.builder();
+      initPhase(builder.addPhase("foo").always(1).startTime(10).startWith("bar"));
+      initPhase(builder.addPhase("bar").always(1));
+      builder.build();
+   }
+
+   @Test
+   public void testStartWithDeadlock() {
+      thrown.expectMessage("Phase dependencies contain cycle");
+      BenchmarkBuilder builder = BenchmarkBuilder.builder();
+      initPhase(builder.addPhase("foo").always(1).startWith("bar"));
+      initPhase(builder.addPhase("bar").always(1).startWith("goo"));
+      initPhase(builder.addPhase("goo").always(1).startWith("foo"));
+      builder.build();
+   }
+
+   @Test
+   public void testMixedDeadlock() {
+      thrown.expectMessage("Phase dependencies contain cycle");
+      BenchmarkBuilder builder = BenchmarkBuilder.builder();
+      initPhase(builder.addPhase("foo").always(1).startAfter("bar"));
+      initPhase(builder.addPhase("bar").always(1).startAfterStrict("goo"));
+      initPhase(builder.addPhase("goo").always(1).startWith("foo"));
       builder.build();
    }
 

--- a/core/src/test/java/io/hyperfoil/core/session/BaseBenchmarkParserTest.java
+++ b/core/src/test/java/io/hyperfoil/core/session/BaseBenchmarkParserTest.java
@@ -1,0 +1,34 @@
+package io.hyperfoil.core.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+
+import io.hyperfoil.api.config.Benchmark;
+import io.hyperfoil.core.parser.BenchmarkParser;
+import io.hyperfoil.core.parser.ParserException;
+import io.hyperfoil.core.test.TestUtil;
+import io.hyperfoil.impl.Util;
+
+public abstract class BaseBenchmarkParserTest {
+
+   protected Benchmark loadScenario(String name) {
+      try {
+         InputStream config = getClass().getClassLoader().getResourceAsStream(name);
+         Benchmark benchmark = loadBenchmark(config);
+         // Serialization here is solely for the purpose of asserting serializability for all the components
+         byte[] bytes = Util.serialize(benchmark);
+         assertThat(bytes).isNotNull();
+         return benchmark;
+      } catch (IOException | ParserException e) {
+         throw new AssertionError(e);
+      }
+   }
+
+   protected Benchmark loadBenchmark(InputStream config) throws IOException, ParserException {
+      return BenchmarkParser.instance().buildBenchmark(config, TestUtil.benchmarkData(), Collections.emptyMap());
+   }
+
+}

--- a/core/src/test/java/io/hyperfoil/core/session/BaseScenarioTest.java
+++ b/core/src/test/java/io/hyperfoil/core/session/BaseScenarioTest.java
@@ -1,13 +1,10 @@
 package io.hyperfoil.core.session;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 
@@ -18,19 +15,11 @@ import io.hyperfoil.api.config.ScenarioBuilder;
 import io.hyperfoil.api.statistics.StatisticsSnapshot;
 import io.hyperfoil.core.impl.LocalSimulationRunner;
 import io.hyperfoil.core.impl.statistics.StatisticsCollector;
-import io.hyperfoil.core.parser.BenchmarkParser;
-import io.hyperfoil.core.parser.ParserException;
-import io.hyperfoil.core.test.TestUtil;
 import io.hyperfoil.core.util.CountDown;
-import io.hyperfoil.impl.Util;
 import io.vertx.core.Vertx;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-
 import io.vertx.ext.unit.TestContext;
 
-public abstract class BaseScenarioTest {
+public abstract class BaseScenarioTest extends BaseBenchmarkParserTest {
    protected final Logger log = LogManager.getLogger(getClass());
 
    protected Vertx vertx;
@@ -52,23 +41,6 @@ public abstract class BaseScenarioTest {
       benchmarkBuilder = BenchmarkBuilder.builder();
       benchmarkBuilder.threads(threads());
       vertx = Vertx.vertx();
-   }
-
-   protected Benchmark loadScenario(String name) {
-      try {
-         InputStream config = getClass().getClassLoader().getResourceAsStream(name);
-         Benchmark benchmark = loadBenchmark(config);
-         // Serialization here is solely for the purpose of asserting serializability for all the components
-         byte[] bytes = Util.serialize(benchmark);
-         assertThat(bytes).isNotNull();
-         return benchmark;
-      } catch (IOException | ParserException e) {
-         throw new AssertionError(e);
-      }
-   }
-
-   protected Benchmark loadBenchmark(InputStream config) throws IOException, ParserException {
-      return BenchmarkParser.instance().buildBenchmark(config, TestUtil.benchmarkData(), Collections.emptyMap());
    }
 
    @After

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/StartWithDelayTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/StartWithDelayTest.java
@@ -1,0 +1,130 @@
+package io.hyperfoil.benchmark.standalone;
+
+import static io.hyperfoil.http.steps.HttpStepCatalog.SC;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import io.hyperfoil.api.config.Benchmark;
+import io.hyperfoil.api.config.BenchmarkBuilder;
+import io.hyperfoil.api.config.Phase;
+import io.hyperfoil.api.config.PhaseReferenceDelay;
+import io.hyperfoil.api.config.RelativeIteration;
+import io.hyperfoil.benchmark.BaseBenchmarkTest;
+import io.hyperfoil.core.handlers.TransferSizeRecorder;
+import io.hyperfoil.core.impl.LocalSimulationRunner;
+import io.hyperfoil.core.impl.statistics.StatisticsCollector;
+import io.hyperfoil.http.api.HttpMethod;
+import io.hyperfoil.http.config.HttpPluginBuilder;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@Category(io.hyperfoil.test.Benchmark.class)
+@RunWith(VertxUnitRunner.class)
+public class StartWithDelayTest extends BaseBenchmarkTest {
+   protected static final Logger log = LogManager.getLogger(StartWithDelayTest.class);
+
+   @Parameterized.Parameters
+   public static Collection<Object[]> data() {
+      return Arrays.asList(new Object[][] {
+            { "additional", "steady", 0 }, { "additional", "steady", 10000 }
+      });
+   }
+
+   @Override
+   protected Handler<HttpServerRequest> getRequestHandler() {
+      return req -> {
+         req.response().end("hello from server");
+      };
+   }
+
+   @Test
+   public void startWith0Delay() {
+      startWithDifferentDelay("additional", "steady", 0);
+   }
+
+   @Test
+   public void startWith10Delay() {
+      startWithDifferentDelay("additional", "steady", 10);
+   }
+
+   public void startWithDifferentDelay(String phase1, String phase2, long delay) {
+      BenchmarkBuilder builder = createBuilder(phase1, phase2, delay);
+      Benchmark benchmark = builder.build();
+
+      // check startWithDelay is correctly setup
+      Phase additionalPhase = benchmark.phases().stream().filter(p -> p.name.equals("additional")).findAny().orElseThrow();
+      assertNotNull(additionalPhase.startWithDelay());
+      assertEquals("steady", additionalPhase.startWithDelay().phase);
+      assertEquals(delay, additionalPhase.startWithDelay().delay);
+
+      StatisticsCollector.StatisticsConsumer statisticsConsumer =
+            (phase, stepId, metric, snapshot, countDown) -> log.debug("Adding stats for {}/{}/{} - #{}: {} requests {} responses", phase, stepId, metric,
+                  snapshot.sequenceId, snapshot.requestCount, snapshot.responseCount);
+      LocalSimulationRunner runner = new LocalSimulationRunner(benchmark, statisticsConsumer, null, null);
+      runner.run();
+
+      // check start time
+      long startTimeDiff = runner.instances().get("additional").absoluteStartTime() - runner.instances().get("steady").absoluteStartTime();
+      assertTrue(startTimeDiff >= delay);
+   }
+
+   /**
+    * create a builder with two phases where the first one should start with the second one after a provided delay
+    */
+   private BenchmarkBuilder createBuilder(String firstPhase, String secondPhase, long startWithDelay) {
+      // @formatter:off
+      BenchmarkBuilder builder = BenchmarkBuilder.builder()
+            .name("startWithDelay " + new SimpleDateFormat("yy/MM/dd HH:mm:ss").format(new Date()))
+            .addPlugin(HttpPluginBuilder::new).http()
+            .host("localhost").port(httpServer.actualPort())
+            .sharedConnections(50)
+            .endHttp().endPlugin()
+            .threads(2);
+
+      builder.addPhase(firstPhase).constantRate(200)
+            .duration(3000)
+            .maxSessions(200 * 15)
+            .startWith(new PhaseReferenceDelay(secondPhase, RelativeIteration.NONE, null, startWithDelay))
+            .scenario()
+               .initialSequence("request")
+                  .step(SC).httpRequest(HttpMethod.GET)
+                  .path("/")
+                  .timeout("60s")
+                     .handler()
+                     .rawBytes(new TransferSizeRecorder("transfer"))
+                     .endHandler()
+                  .endStep()
+               .endSequence();
+
+      builder.addPhase(secondPhase).constantRate(200)
+            .duration(3000)
+            .maxSessions(200 * 15)
+            .scenario()
+               .initialSequence("request")
+                  .step(SC).httpRequest(HttpMethod.GET)
+                  .path("/")
+                  .timeout("60s")
+                     .handler()
+                     .rawBytes(new TransferSizeRecorder("transfer"))
+                     .endHandler()
+                  .endStep()
+               .endSequence();
+      // @formatter:on
+
+      return builder;
+   }
+}

--- a/test-suite/src/test/resources/scenarios/start-with-delay.hf.yaml
+++ b/test-suite/src/test/resources/scenarios/start-with-delay.hf.yaml
@@ -1,0 +1,60 @@
+name: benchmark using start with delay
+http:
+  host: http://localhost:8080
+phases:
+- rampUp: # start this load 4s after the steady state, for 4s they will run in parallel
+    increasingRate:
+      initialUsersPerSec: 1
+      targetUsersPerSec: 100
+      duration: 3s
+      startWith:
+        phase: steadyState
+        delay: 4s
+      scenario: &scenario
+        initialSequences:
+        - testSequence:
+          - httpRequest:
+              GET: /foo
+              sync: false
+              sla:
+                meanResponseTime: 1s
+                limits:
+                  0.9: 2s
+              handler:
+                status:
+                  counter:
+                    expectStatus: 204
+                    var: testCounter
+                    init: 0
+                    add: 1
+          - set: foo <- bar
+          - httpRequest:
+              method: GET
+              path: /foo
+              sync: false
+              headers:
+              - Accept: text/plain
+              - Foo:
+                  fromVar: foo
+              handler:
+              # notice this is a list, for repeated invocations
+              - status:
+                  counter:
+                    expectStatus: 204
+                    var: testCounter
+                    init: 0
+                    add: 1
+          - noop
+          - awaitInt:
+              var: testCounter
+              greaterOrEqualTo: 2
+          - scheduleDelay:
+              key: k
+              fromNow:
+              duration: 5s
+
+- steadyState:
+    constantRate:
+      usersPerSec: 100
+      duration: 8s
+      scenario: *scenario


### PR DESCRIPTION
Fixes https://github.com/Hyperfoil/Hyperfoil/issues/239

**Improvement:**
With this new `startWith` with `delay` feature, users can actually sync phases between each other.

**Usage:**

This is an example where you could start a `phase1` after 5 seconds that the coupled `phase2` has started.

```yaml
name: first-swd
http:
  host: http://localhost:8080
  sharedConnections: 10
phases:
- phase1:
    constantRate:
      usersPerSec: 10
      duration: 10s
      startWith:
        phase: phase2
        delay: 5s
      scenario:
      - fetchIndex:
        - httpRequest:
            GET: /
- phase2:
    constantRate:
      usersPerSec: 10
      duration: 10s
      scenario:
      - fetchDetails:
        - httpRequest:
            GET: /offering/1

```

Its definition is quite similar to the `startAfter` feature, the main differences are:
- There is the additional `delay` field
- You **cannot** provide a list of `startWith` as it does not make sense by design, and of course circular dependencies are not allowed too.

> **Note:** right now if you set `delay=0` the code checks if the coupled phase has been already started before marking the current one as available. This means that the current phase will start in the next available slot, therefore even with `delay=0` there is an intrisic delay `> 0`