### PR TITLE
Fix plugins definition after jboss-parent removal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,10 +101,12 @@
         <version.sonatype.nexus>1.6.13</version.sonatype.nexus>
         <version.maven.source>3.2.1</version.maven.source>
         <version.maven.javadoc>3.4.1</version.maven.javadoc>
-        <version.maven.gpg>3.0.1</version.maven.gpg>
+        <version.maven.gpg>1.6</version.maven.gpg>
         <version.maven-core>3.8.6</version.maven-core>
         <version.maven-plugin-annotations>3.7.0</version.maven-plugin-annotations>
         <version.maven-surefire-plugin>3.0.0-M7</version.maven-surefire-plugin>
+        <version.antrun.plugin>1.8</version.antrun.plugin>
+        <version.assembly.plugin>2.5.5</version.assembly.plugin>
 
         <exec.skip>true</exec.skip>
         <module.skipCopyDependencies>false</module.skipCopyDependencies>
@@ -451,6 +453,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>${version.antrun.plugin}</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>
@@ -471,6 +474,31 @@
 
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>${version.assembly.plugin}</version>
+                    <configuration>
+                        <archive>
+                            <index>true</index>
+                            <manifest>
+                                <addDefaultSpecificationEntries> true </addDefaultSpecificationEntries>
+                                <addDefaultImplementationEntries> true </addDefaultImplementationEntries>
+                            </manifest>
+                            <manifestEntries>
+                                <Implementation-URL>${project.url}</Implementation-URL>
+                                <Java-Version>${java.version}</Java-Version>
+                                <Java-Vendor>${java.vendor}</Java-Vendor>
+                                <Os-Name>${os.name}</Os-Name>
+                                <Os-Arch>${os.arch}</Os-Arch>
+                                <Os-Version>${os.version}</Os-Version>
+                                <Scm-Url>${project.scm.url}</Scm-Url>
+                                <Scm-Connection>${project.scm.connection}</Scm-Connection>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
+                </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
With this commit https://github.com/Hyperfoil/Hyperfoil/commit/c37d32dc10da7b2163d36274825603eea5434c56 the `jboss-parent` has been removed, with that also `pluginManagement` definition.

Since that commit CI builds started failing with this:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Hyperfoil 0.25-SNAPSHOT:
[INFO] 
[INFO] Hyperfoil .......................................... SUCCESS [  0.904 s]
[INFO] Hyperfoil API ...................................... SUCCESS [  7.280 s]
[INFO] Hyperfoil Core ..................................... SUCCESS [  7.159 s]
[INFO] Hyperfoil HTTP Client .............................. SUCCESS [01:33 min]
[INFO] Hyperfoil Code Generator ........................... SUCCESS [  1.856 s]
[INFO] Hyperfoil Controller API ........................... SUCCESS [  0.903 s]
[INFO] Hyperfoil CLI ...................................... SUCCESS [  2.160 s]
[INFO] Hyperfoil Clustering ............................... SUCCESS [  1.698 s]
[INFO] Hyperfoil Hot Rod Client ........................... SUCCESS [ 23.951 s]
[INFO] Hyperfoil Kubernetes Deployer ...................... SUCCESS [  0.474 s]
[INFO] Hyperfoil Distribution ............................. FAILURE [  4.866 s]
[INFO] Hyperfoil Test-Suite ............................... SKIPPED
[INFO] Hyperfoil Maven Plugin ............................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:24 min
[INFO] Finished at: 2023-06-28T16:06:09Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.6.0:exec (schema) on project hyperfoil-distribution: Command execution failed. Process exited with an error: 1 (Exit value: 1) -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :hyperfoil-distribution
Error: Process completed with exit code 1.
```
The root cause seems to me the `antr-plugin` for which we do not have explicit version set, therefore it was using version 1.3 `--- maven-antrun-plugin:1.3:run (default) @ hyperfoil-distribution` whose behavior is different to the one expected.

Was the jboss-parent removal intentional? If so I think there could be other plugins for which we would have to provide the expliciti managed version, wdyt?

For now explicitly setting `antlr` and `assembly` plugin seemed enough to fix the issue.