### PR TITLE
Upgrade snakeyaml and sshd-core

### DIFF
--- a/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployedAgent.java
+++ b/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployedAgent.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 import org.apache.sshd.client.channel.ChannelShell;
 import org.apache.sshd.client.channel.ClientChannel;
 import org.apache.sshd.client.future.OpenFuture;
+import org.apache.sshd.common.util.io.output.NullOutputStream;
 import org.apache.sshd.scp.client.ScpClient;
 import org.apache.sshd.scp.client.ScpClientCreator;
 import org.apache.sshd.client.session.ClientSession;
@@ -25,7 +26,6 @@ import org.apache.sshd.sftp.client.SftpClientFactory;
 import org.apache.sshd.common.io.IoOutputStream;
 import org.apache.sshd.common.io.IoReadFuture;
 import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
-import org.apache.sshd.common.util.io.NullOutputStream;
 
 import io.hyperfoil.api.BenchmarkExecutionException;
 import io.hyperfoil.api.deployment.DeployedAgent;

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <version.metainf-services>1.8</version.metainf-services>
         <version.netty.tcnative.boringssl>2.0.54.Final</version.netty.tcnative.boringssl>
         <version.slf4j>2.0.6</version.slf4j>
-        <version.snakeyaml>1.33</version.snakeyaml>
+        <version.snakeyaml>2.0</version.snakeyaml>
         <version.vertx>4.3.7</version.vertx>
         <version.infinispan>13.0.8.Final</version.infinispan>
         <version.jboss-threads>3.5.0.Final</version.jboss-threads>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <maven.compiler.source>11</maven.compiler.source>
 
         <version.aesh>2.7</version.aesh>
-        <version.apache.sshd>2.7.0</version.apache.sshd>
+        <version.apache.sshd>2.9.2</version.apache.sshd>
         <version.assertj>3.10.0</version.assertj>
         <version.eddsa>0.3.0</version.eddsa>
         <version.fabric8.kubernetes-client>4.7.2</version.fabric8.kubernetes-client>
@@ -439,7 +439,7 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                                 <requireReleaseDeps>
                                     <excludes>io.hyperfoil:*</excludes>
                                     <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
@@ -463,8 +463,8 @@
                         </goals>
                         <configuration>
                             <target>
-                                <copy file="${project.basedir}/config/pre-commit" todir="${project.basedir}/.git/hooks" />
-                                <chmod file="${project.basedir}/.git/hooks/pre-commit" perm="a+x" />
+                                <copy file="${project.basedir}/config/pre-commit" todir="${project.basedir}/.git/hooks"/>
+                                <chmod file="${project.basedir}/.git/hooks/pre-commit" perm="a+x"/>
                             </target>
                         </configuration>
                     </execution>
@@ -482,8 +482,8 @@
                         <archive>
                             <index>true</index>
                             <manifest>
-                                <addDefaultSpecificationEntries> true </addDefaultSpecificationEntries>
-                                <addDefaultImplementationEntries> true </addDefaultImplementationEntries>
+                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                             </manifest>
                             <manifestEntries>
                                 <Implementation-URL>${project.url}</Implementation-URL>


### PR DESCRIPTION
Upgrade some libs:
- Upgrade sshd-core to `2.9.2`, fix https://nvd.nist.gov/vuln/detail/CVE-2022-45047
- Upgrade snakeyaml to `2.0`, fix https://nvd.nist.gov/vuln/detail/CVE-2022-1471