### PR TITLE
[s390x] Define utf-8 encoding in compiler plugin 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -607,6 +607,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
+                        <encoding>UTF-8</encoding>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>


### PR DESCRIPTION
With this change, we are able to compile hyperfoil in s390x environment