### PR TITLE
Set CPU Request in Benchmark

### DIFF
--- a/k8s-deployer/src/main/java/io/hyperfoil/deploy/k8s/K8sDeployer.java
+++ b/k8s-deployer/src/main/java/io/hyperfoil/deploy/k8s/K8sDeployer.java
@@ -143,7 +143,13 @@ public class K8sDeployer implements Deployer {
       int threads = agent.threads() < 0 ? benchmark.defaultThreads() : agent.threads();
       ResourceRequirements resourceRequirements = new ResourceRequirements();
       Map<String, Quantity> podResourceRequests = new LinkedHashMap<>();
-      podResourceRequests.put("cpu", new Quantity(String.valueOf(threads)));
+      String cpuRequest = agent.properties.getOrDefault(
+              "pod-cpu",
+              Properties.get("io.hyperfoil.deployer.k8s.pod.cpu", null)
+      );
+      if (cpuRequest != null) {
+         podResourceRequests.put("cpu", new Quantity(cpuRequest));
+      }
       String memoryRequest = agent.properties.getOrDefault(
               "pod-memory",
               Properties.get("io.hyperfoil.deployer.k8s.pod.memory", null)


### PR DESCRIPTION
This change is needed to set CPU request in the Hyperfoil agent through benchmark.

Log of build:

[root@xxxx Hyperfoil]# mvn -DskipTests=true package
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.hyperfoil:hyperfoil-test-suite:jar:0.26-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-gpg-plugin is missing. @ line 137, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: linux
[INFO] os.detected.arch: s390_64
[INFO] os.detected.release: rhel
[INFO] os.detected.release.version: 8.6
[INFO] os.detected.release.like.rhel: true
[INFO] os.detected.release.like.fedora: true
[INFO] os.detected.classifier: linux-s390_64
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] Hyperfoil                                                          [pom]
[INFO] Hyperfoil API                                                      [jar]
[INFO] Hyperfoil Core                                                     [jar]
[INFO] Hyperfoil HTTP Client                                              [jar]
[INFO] Hyperfoil Code Generator                                  [maven-plugin]
[INFO] Hyperfoil Controller API                                           [jar]
[INFO] Hyperfoil CLI                                                      [jar]
[INFO] Hyperfoil Clustering                                               [jar]
[INFO] Hyperfoil Hot Rod Client                                           [jar]
[INFO] Hyperfoil Kubernetes Deployer                                      [jar]
[INFO] Hyperfoil Distribution                                             [pom]
[INFO] Hyperfoil Test-Suite                                               [jar]
[INFO] Hyperfoil Maven Plugin                                    [maven-plugin]
[INFO] 
[INFO] ---------------------< io.hyperfoil:hyperfoil-all >---------------------
[INFO] Building Hyperfoil 0.26-SNAPSHOT                                  [1/13]
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-all ---
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-all ---
[INFO] Executing: /bin/sh -c cd /root/ankita/hyperfoil/Hyperfoil && git rev-parse --verify HEAD
[INFO] Working directory: /root/ankita/hyperfoil/Hyperfoil
[INFO] Storing buildNumber: 91021e2d8fc4d6671a0ceb4629661f25751fd1ba at timestamp: 1699435661891
[INFO] Storing buildScmBranch: master
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-all ---
[INFO] 
[INFO] ---------------------< io.hyperfoil:hyperfoil-api >---------------------
[INFO] Building Hyperfoil API 0.26-SNAPSHOT                              [2/13]
[INFO]   from api/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-api ---
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-api ---
[WARNING] File encoding has not been set, using platform encoding ANSI_X3.4-1968, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-api ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-api ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/api/src/main/resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-api ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-api ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/api/src/test/resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-api ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-api ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-api ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/api/target/hyperfoil-api-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-api ---
[INFO] 
[INFO] --------------------< io.hyperfoil:hyperfoil-core >---------------------
[INFO] Building Hyperfoil Core 0.26-SNAPSHOT                             [3/13]
[INFO]   from core/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-core ---
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-core ---
[WARNING] File encoding has not been set, using platform encoding ANSI_X3.4-1968, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-core ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-core ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 1 resource
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-core ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 183 source files to /root/ankita/hyperfoil/Hyperfoil/core/target/classes
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-core ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 14 resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-core ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 22 source files to /root/ankita/hyperfoil/Hyperfoil/core/target/test-classes
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-core ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-core ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/core/target/hyperfoil-core-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-core ---
[INFO] 
[INFO] --- jar:3.0.2:test-jar (default) @ hyperfoil-core ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/core/target/hyperfoil-core-0.26-SNAPSHOT-tests.jar
[INFO] 
[INFO] --------------------< io.hyperfoil:hyperfoil-http >---------------------
[INFO] Building Hyperfoil HTTP Client 0.26-SNAPSHOT                      [4/13]
[INFO]   from http/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-http ---
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-http ---
[WARNING] File encoding has not been set, using platform encoding ANSI_X3.4-1968, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-http ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-http ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/http/src/main/resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-http ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-http ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 9 resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-http ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-http ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-http ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/http/target/hyperfoil-http-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-http ---
[INFO] 
[INFO] --- jar:3.0.2:test-jar (default) @ hyperfoil-http ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/http/target/hyperfoil-http-0.26-SNAPSHOT-tests.jar
[INFO] 
[INFO] ------------< io.hyperfoil:hyperfoil-codegen-maven-plugin >-------------
[INFO] Building Hyperfoil Code Generator 0.26-SNAPSHOT                   [5/13]
[INFO]   from plugins/codegen/pom.xml
[INFO] ----------------------------[ maven-plugin ]----------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-codegen-maven-plugin ---
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-codegen-maven-plugin ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-codegen-maven-plugin ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/plugins/codegen/src/main/resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-codegen-maven-plugin ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- plugin:3.6.0:descriptor (default-descriptor) @ hyperfoil-codegen-maven-plugin ---
[INFO] Using 'UTF-8' encoding to read mojo source files.
[INFO] java-javadoc mojo extractor found 0 mojo descriptor.
[INFO] java-annotations mojo extractor found 2 mojo descriptors.
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-codegen-maven-plugin ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/plugins/codegen/src/test/resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-codegen-maven-plugin ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-codegen-maven-plugin ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-codegen-maven-plugin ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/plugins/codegen/target/hyperfoil-codegen-maven-plugin-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- plugin:3.6.0:addPluginArtifactMetadata (default-addPluginArtifactMetadata) @ hyperfoil-codegen-maven-plugin ---
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-codegen-maven-plugin ---
[INFO] 
[INFO] ---------------< io.hyperfoil:hyperfoil-controller-api >----------------
[INFO] Building Hyperfoil Controller API 0.26-SNAPSHOT                   [6/13]
[INFO]   from controller-api/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-controller-api ---
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-controller-api ---
[INFO] 
[INFO] --- hyperfoil-codegen:0.26-SNAPSHOT:codegen (default) @ hyperfoil-controller-api ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-controller-api ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 1 resource
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-controller-api ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 11 source files to /root/ankita/hyperfoil/Hyperfoil/controller-api/target/classes
[INFO] 
[INFO] --- compiler:3.8.1:compile (compile-proxy-handler) @ hyperfoil-controller-api ---
[WARNING]  Parameter 'compileSourceRoots' is read-only, must not be used in configuration
[INFO] Changes detected - recompiling the module!
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-controller-api ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/controller-api/src/test/resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-controller-api ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-controller-api ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-controller-api ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/controller-api/target/hyperfoil-controller-api-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-controller-api ---
[INFO] 
[INFO] ---------------------< io.hyperfoil:hyperfoil-cli >---------------------
[INFO] Building Hyperfoil CLI 0.26-SNAPSHOT                              [7/13]
[INFO]   from cli/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-cli ---
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-cli ---
[WARNING] File encoding has not been set, using platform encoding ANSI_X3.4-1968, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-cli ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-cli ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 4 resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-cli ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-cli ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/cli/src/test/resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-cli ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-cli ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-cli ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/cli/target/hyperfoil-cli-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-cli ---
[INFO] 
[INFO] -----------------< io.hyperfoil:hyperfoil-clustering >------------------
[INFO] Building Hyperfoil Clustering 0.26-SNAPSHOT                       [8/13]
[INFO]   from clustering/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-clustering ---
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-clustering ---
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-clustering ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-clustering ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 9 resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-clustering ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 54 source files to /root/ankita/hyperfoil/Hyperfoil/clustering/target/classes
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-clustering ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/clustering/src/test/resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-clustering ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-clustering ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-clustering ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/clustering/target/hyperfoil-clustering-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-clustering ---
[INFO] 
[INFO] -------------------< io.hyperfoil:hyperfoil-hotrod >--------------------
[INFO] Building Hyperfoil Hot Rod Client 0.26-SNAPSHOT                   [9/13]
[INFO]   from hotrod/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-hotrod ---
[WARNING] File encoding has not been set, using platform encoding ANSI_X3.4-1968, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-hotrod ---
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-hotrod ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-hotrod ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/hotrod/src/main/resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-hotrod ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-hotrod ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 2 resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-hotrod ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-hotrod ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-hotrod ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/hotrod/target/hyperfoil-hotrod-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-hotrod ---
[INFO] 
[INFO] --- shade:3.2.4:shade (default) @ hyperfoil-hotrod ---
[INFO] Including org.infinispan:infinispan-client-hotrod:jar:13.0.8.Final in the shaded jar.
[INFO] Including org.infinispan:infinispan-commons:jar:13.0.8.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-sasl-digest:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-auth-server:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-auth:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-base:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-permission:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-x500:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-credential:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-keystore:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-x500-cert:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-x500-cert-util:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-provider-util:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-mechanism:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-http:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-mechanism-digest:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-sasl:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-ssl:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-util:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.common:wildfly-common:jar:1.6.0.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-sasl-external:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-sasl-gs2:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-asn1:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-mechanism-gssapi:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-security-manager-action:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-sasl-gssapi:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-sasl-oauth2:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-mechanism-oauth2:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-sasl-plain:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-sasl-scram:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-mechanism-scram:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.wildfly.security:wildfly-elytron-password-impl:jar:1.17.2.Final in the shaded jar.
[INFO] Including org.infinispan.protostream:protostream:jar:4.4.1.Final in the shaded jar.
[INFO] Including org.infinispan.protostream:protostream-types:jar:4.4.1.Final in the shaded jar.
[INFO] Excluding io.hyperfoil:hyperfoil-core:jar:0.26-SNAPSHOT from the shaded jar.
[INFO] Excluding io.hyperfoil:hyperfoil-api:jar:0.26-SNAPSHOT from the shaded jar.
[INFO] Excluding org.hdrhistogram:HdrHistogram:jar:2.1.11 from the shaded jar.
[INFO] Excluding org.apache.logging.log4j:log4j-api:jar:2.19.0 from the shaded jar.
[INFO] Excluding org.apache.logging.log4j:log4j-core:jar:2.19.0 from the shaded jar.
[INFO] Excluding org.apache.logging.log4j:log4j-slf4j-impl:jar:2.19.0 from the shaded jar.
[INFO] Excluding org.slf4j:slf4j-api:jar:2.0.6 from the shaded jar.
[INFO] Excluding org.yaml:snakeyaml:jar:2.0 from the shaded jar.
[INFO] Excluding io.netty:netty-tcnative-boringssl-static:jar:2.0.56.Final from the shaded jar.
[INFO] Excluding io.netty:netty-tcnative-classes:jar:2.0.56.Final from the shaded jar.
[INFO] Excluding io.netty:netty-tcnative-boringssl-static:jar:linux-x86_64:2.0.56.Final from the shaded jar.
[INFO] Excluding io.netty:netty-tcnative-boringssl-static:jar:linux-aarch_64:2.0.56.Final from the shaded jar.
[INFO] Excluding io.netty:netty-tcnative-boringssl-static:jar:osx-x86_64:2.0.56.Final from the shaded jar.
[INFO] Excluding io.netty:netty-tcnative-boringssl-static:jar:osx-aarch_64:2.0.56.Final from the shaded jar.
[INFO] Excluding io.netty:netty-tcnative-boringssl-static:jar:windows-x86_64:2.0.56.Final from the shaded jar.
[INFO] Excluding io.netty:netty-transport-native-epoll:jar:linux-x86_64:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-common:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-buffer:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-transport:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-transport-native-unix-common:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-transport-classes-epoll:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-transport-classes-kqueue:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-resolver-dns-native-macos:jar:osx-x86_64:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-resolver-dns-classes-macos:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-resolver-dns-native-macos:jar:osx-aarch_64:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-transport-native-epoll:jar:linux-aarch_64:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-transport-native-kqueue:jar:osx-aarch_64:4.1.87.Final from the shaded jar.
[INFO] Excluding org.kohsuke.metainf-services:metainf-services:jar:1.8 from the shaded jar.
[INFO] Excluding org.jboss.logging:jboss-logging:jar:3.5.0.Final from the shaded jar.
[INFO] Excluding io.netty:netty-handler:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-resolver:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-codec:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding jakarta.transaction:jakarta.transaction-api:jar:1.3.3 from the shaded jar.
[INFO] Excluding com.fasterxml.jackson.core:jackson-core:jar:2.14.0 from the shaded jar.
[INFO] Excluding com.fasterxml.jackson.core:jackson-databind:jar:2.15.2 from the shaded jar.
[INFO] Excluding com.fasterxml.jackson.core:jackson-annotations:jar:2.14.0 from the shaded jar.
[INFO] Excluding io.vertx:vertx-core:jar:4.3.8 from the shaded jar.
[INFO] Excluding io.netty:netty-handler-proxy:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-codec-socks:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-codec-http:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-codec-http2:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-resolver-dns:jar:4.1.87.Final from the shaded jar.
[INFO] Excluding io.netty:netty-codec-dns:jar:4.1.87.Final from the shaded jar.
[WARNING] hyperfoil-hotrod-0.26-SNAPSHOT.jar, infinispan-client-hotrod-13.0.8.Final.jar, infinispan-commons-13.0.8.Final.jar, protostream-4.4.1.Final.jar, protostream-types-4.4.1.Final.jar, wildfly-common-1.6.0.Final.jar, wildfly-elytron-asn1-1.17.2.Final.jar, wildfly-elytron-auth-1.17.2.Final.jar, wildfly-elytron-auth-server-1.17.2.Final.jar, wildfly-elytron-base-1.17.2.Final.jar, wildfly-elytron-credential-1.17.2.Final.jar, wildfly-elytron-http-1.17.2.Final.jar, wildfly-elytron-keystore-1.17.2.Final.jar, wildfly-elytron-mechanism-1.17.2.Final.jar, wildfly-elytron-mechanism-digest-1.17.2.Final.jar, wildfly-elytron-mechanism-gssapi-1.17.2.Final.jar, wildfly-elytron-mechanism-oauth2-1.17.2.Final.jar, wildfly-elytron-mechanism-scram-1.17.2.Final.jar, wildfly-elytron-password-impl-1.17.2.Final.jar, wildfly-elytron-permission-1.17.2.Final.jar, wildfly-elytron-provider-util-1.17.2.Final.jar, wildfly-elytron-sasl-1.17.2.Final.jar, wildfly-elytron-sasl-digest-1.17.2.Final.jar, wildfly-elytron-sasl-external-1.17.2.Final.jar, wildfly-elytron-sasl-gs2-1.17.2.Final.jar, wildfly-elytron-sasl-gssapi-1.17.2.Final.jar, wildfly-elytron-sasl-oauth2-1.17.2.Final.jar, wildfly-elytron-sasl-plain-1.17.2.Final.jar, wildfly-elytron-sasl-scram-1.17.2.Final.jar, wildfly-elytron-security-manager-action-1.17.2.Final.jar, wildfly-elytron-ssl-1.17.2.Final.jar, wildfly-elytron-util-1.17.2.Final.jar, wildfly-elytron-x500-1.17.2.Final.jar, wildfly-elytron-x500-cert-1.17.2.Final.jar, wildfly-elytron-x500-cert-util-1.17.2.Final.jar define 1 overlapping resource: 
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] infinispan-client-hotrod-13.0.8.Final.jar, infinispan-commons-13.0.8.Final.jar define 1 overlapping resource: 
[WARNING]   - META-INF/licenses.xml
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See http://maven.apache.org/plugins/maven-shade-plugin/
[INFO] Replacing /root/ankita/hyperfoil/Hyperfoil/hotrod/target/hyperfoil-hotrod-shaded.jar with /root/ankita/hyperfoil/Hyperfoil/hotrod/target/hyperfoil-hotrod-0.26-SNAPSHOT-shaded.jar
[INFO] 
[INFO] --- antrun:1.8:run (default) @ hyperfoil-hotrod ---
[INFO] Executing tasks

main:
    [unzip] Expanding: /root/ankita/hyperfoil/Hyperfoil/hotrod/target/hyperfoil-hotrod-shaded.jar into /root/ankita/hyperfoil/Hyperfoil/hotrod/target/shaded
     [move] Moving 6 files to /root/ankita/hyperfoil/Hyperfoil/hotrod/target/shaded/shaded
      [jar] Building jar: /root/ankita/hyperfoil/Hyperfoil/hotrod/target/hyperfoil-hotrod-0.26-SNAPSHOT.jar
[INFO] Executed tasks
[INFO] 
[INFO] ----------------< io.hyperfoil:hyperfoil-k8s-deployer >-----------------
[INFO] Building Hyperfoil Kubernetes Deployer 0.26-SNAPSHOT             [10/13]
[INFO]   from k8s-deployer/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-k8s-deployer ---
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-k8s-deployer ---
[WARNING] File encoding has not been set, using platform encoding ANSI_X3.4-1968, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-k8s-deployer ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-k8s-deployer ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/k8s-deployer/src/main/resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-k8s-deployer ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-k8s-deployer ---
[WARNING] Using platform encoding (ANSI_X3.4-1968 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/k8s-deployer/src/test/resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-k8s-deployer ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-k8s-deployer ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-k8s-deployer ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/k8s-deployer/target/hyperfoil-k8s-deployer-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-k8s-deployer ---
[INFO] 
[INFO] ----------------< io.hyperfoil:hyperfoil-distribution >-----------------
[INFO] Building Hyperfoil Distribution 0.26-SNAPSHOT                    [11/13]
[INFO]   from distribution/pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-distribution ---
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-distribution ---
[WARNING] File encoding has not been set, using platform encoding ANSI_X3.4-1968, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-distribution ---
[INFO] 
[INFO] --- compiler:3.8.1:compile (compile) @ hyperfoil-distribution ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (test-compile) @ hyperfoil-distribution ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (test) @ hyperfoil-distribution ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-distribution ---
[INFO] 
[INFO] --- jar:3.0.2:jar (default) @ hyperfoil-distribution ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/distribution/target/hyperfoil-distribution-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- antrun:1.8:run (default) @ hyperfoil-distribution ---
[INFO] Executing tasks

main:

clean:
   [delete] Deleting directory /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution

all:
    [mkdir] Created dir: /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/docs
    [mkdir] Created dir: /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/examples
    [mkdir] Created dir: /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/bin
    [mkdir] Created dir: /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/lib
    [mkdir] Created dir: /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/extensions
    [mkdir] Created dir: /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/templates
     [copy] Copying 24 files to /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/lib
     [copy] Copying 30 files to /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/lib
     [copy] Copying 26 files to /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/lib
     [copy] Copying 15 files to /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/lib
     [copy] Copying 1 file to /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/lib
     [copy] Copying 7 files to /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/bin
     [copy] Copying 12 files to /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/examples
     [copy] Copying 1 file to /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/extensions
      [get] Getting: http://hyperfoil.io/report-template-v3.0.html
      [get] To: /root/ankita/hyperfoil/Hyperfoil/distribution/target/distribution/templates/report-template-v3.0.html
      [get] http://hyperfoil.io/report-template-v3.0.html permanently moved to https://hyperfoil.io/report-template-v3.0.html

package:
[INFO] Executed tasks
[INFO] 
[INFO] --- exec:1.6.0:exec (schema) @ hyperfoil-distribution ---
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/root/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.19.0/log4j-slf4j-impl-2.19.0.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
[INFO] 
[INFO] --- exec:1.6.0:exec (docs) @ hyperfoil-distribution ---
Cannot find source code for class io.hyperfoil.example.DivideStep
[INFO] 
[INFO] --- assembly:2.5.5:single (create-distribution-zip) @ hyperfoil-distribution ---
[INFO] Reading assembly descriptor: src/assembly/assembly.xml
[INFO] Building zip: /root/ankita/hyperfoil/Hyperfoil/distribution/target/hyperfoil-0.26-SNAPSHOT.zip
[INFO] 
[INFO] -----------------< io.hyperfoil:hyperfoil-test-suite >------------------
[INFO] Building Hyperfoil Test-Suite 0.26-SNAPSHOT                      [12/13]
[INFO]   from test-suite/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-test-suite ---
[INFO] 
[INFO] --- checkstyle:2.17:check (validate) @ hyperfoil-test-suite ---
[INFO] Starting audit...
Audit done.
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-test-suite ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-test-suite ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/test-suite/src/main/resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-test-suite ---
[INFO] No sources to compile
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-test-suite ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 23 resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-test-suite ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-test-suite ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-test-suite ---
[INFO] Skipping packaging of the jar
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-test-suite ---
[INFO] 
[INFO] ----------------< io.hyperfoil:hyperfoil-maven-plugin >-----------------
[INFO] Building Hyperfoil Maven Plugin 0.26-SNAPSHOT                    [13/13]
[INFO]   from plugins/maven/pom.xml
[INFO] ----------------------------[ maven-plugin ]----------------------------
[INFO] 
[INFO] --- enforcer:3.0.0-M2:enforce (enforce-maven) @ hyperfoil-maven-plugin ---
[INFO] 
[INFO] --- buildnumber:1.3:create (get-scm-revision) @ hyperfoil-maven-plugin ---
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ hyperfoil-maven-plugin ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/plugins/maven/src/main/resources
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ hyperfoil-maven-plugin ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- plugin:3.6.0:descriptor (default-descriptor) @ hyperfoil-maven-plugin ---
[INFO] Using 'UTF-8' encoding to read mojo source files.
[INFO] java-javadoc mojo extractor found 0 mojo descriptor.
[INFO] java-annotations mojo extractor found 1 mojo descriptor.
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ hyperfoil-maven-plugin ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /root/ankita/hyperfoil/Hyperfoil/plugins/maven/src/test/resources
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ hyperfoil-maven-plugin ---
[INFO] No sources to compile
[INFO] 
[INFO] --- surefire:3.0.0-M7:test (default-test) @ hyperfoil-maven-plugin ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- jar:3.0.2:jar (default-jar) @ hyperfoil-maven-plugin ---
[INFO] Building jar: /root/ankita/hyperfoil/Hyperfoil/plugins/maven/target/hyperfoil-maven-plugin-0.26-SNAPSHOT.jar
[INFO] 
[INFO] --- plugin:3.6.0:addPluginArtifactMetadata (default-addPluginArtifactMetadata) @ hyperfoil-maven-plugin ---
[INFO] 
[INFO] --- dependency:3.0.2:copy-dependencies (copy-dependencies) @ hyperfoil-maven-plugin ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Hyperfoil 0.26-SNAPSHOT:
[INFO] 
[INFO] Hyperfoil .......................................... SUCCESS [  1.900 s]
[INFO] Hyperfoil API ...................................... SUCCESS [  1.753 s]
[INFO] Hyperfoil Core ..................................... SUCCESS [  4.612 s]
[INFO] Hyperfoil HTTP Client .............................. SUCCESS [  0.491 s]
[INFO] Hyperfoil Code Generator ........................... SUCCESS [  1.082 s]
[INFO] Hyperfoil Controller API ........................... SUCCESS [  0.527 s]
[INFO] Hyperfoil CLI ...................................... SUCCESS [  1.024 s]
[INFO] Hyperfoil Clustering ............................... SUCCESS [  1.717 s]
[INFO] Hyperfoil Hot Rod Client ........................... SUCCESS [  2.648 s]
[INFO] Hyperfoil Kubernetes Deployer ...................... SUCCESS [  0.188 s]
[INFO] Hyperfoil Distribution ............................. SUCCESS [  5.950 s]
[INFO] Hyperfoil Test-Suite ............................... SUCCESS [  0.274 s]
[INFO] Hyperfoil Maven Plugin ............................. SUCCESS [  0.461 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  22.886 s
[INFO] Finished at: 2023-11-08T04:28:02-05:00
[INFO] ------------------------------------------------------------------------