### PR TITLE
WebCLI should use returned hostname instead of always localhost

### DIFF
--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerServer.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerServer.java
@@ -34,6 +34,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.hyperfoil.api.Version;
 import io.hyperfoil.api.config.Benchmark;
 import io.hyperfoil.api.config.BenchmarkData;
@@ -81,9 +84,6 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.FaviconHandler;
 import io.vertx.ext.web.handler.StaticHandler;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 class ControllerServer implements ApiService {
    private static final Logger log = LogManager.getLogger(ControllerServer.class);
@@ -164,21 +164,21 @@ class ControllerServer implements ApiService {
             .webSocketHandler(webCLI)
             .listen(controllerPort, controllerHost, serverResult -> {
                if (serverResult.succeeded()) {
-                  if (CONTROLLER_EXTERNAL_URI == null) {
-                     String host = controllerHost;
-                     // Can't advertise 0.0.0.0 as
-                     if (host.equals("0.0.0.0")) {
-                        try {
-                           host = InetAddress.getLocalHost().getHostName();
-                        } catch (UnknownHostException e) {
-                           host = "localhost";
-                        }
+                  String host = controllerHost;
+                  // Can't advertise 0.0.0.0 as
+                  if (host.equals("0.0.0.0")) {
+                     try {
+                        host = InetAddress.getLocalHost().getHostName();
+                     } catch (UnknownHostException e) {
+                        host = "localhost";
                      }
+                  }
+                  if (CONTROLLER_EXTERNAL_URI == null) {
                      baseURL = (options.isSsl() ? "https://" : "http://") + host + ":" + serverResult.result().actualPort();
                   } else {
                      baseURL = CONTROLLER_EXTERNAL_URI;
                   }
-                  webCLI.setConnectionOptions(serverResult.result().actualPort(), options.isSsl());
+                  webCLI.setConnectionOptions(host, serverResult.result().actualPort(), options.isSsl());
                   log.info("Hyperfoil controller listening on {}", baseURL);
                }
                countDown.handle(serverResult.mapEmpty());

--- a/clustering/src/main/java/io/hyperfoil/clustering/webcli/WebCLI.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/webcli/WebCLI.java
@@ -24,6 +24,10 @@ import org.aesh.readline.terminal.impl.ExternalTerminal;
 import org.aesh.readline.terminal.impl.LineDisciplineTerminal;
 import org.aesh.readline.tty.terminal.TerminalConnection;
 import org.aesh.terminal.tty.Signal;
+import org.aesh.terminal.tty.Size;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.FormattedMessage;
 
 import io.hyperfoil.cli.HyperfoilCli;
 import io.hyperfoil.cli.commands.Connect;
@@ -40,11 +44,6 @@ import io.hyperfoil.impl.Util;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.ServerWebSocket;
-
-import org.aesh.terminal.tty.Size;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.message.FormattedMessage;
 
 public class WebCLI extends HyperfoilCli implements Handler<ServerWebSocket> {
    private static final Logger log = LogManager.getLogger(WebCLI.class);
@@ -64,6 +63,7 @@ public class WebCLI extends HyperfoilCli implements Handler<ServerWebSocket> {
    private final Vertx vertx;
    private final ConcurrentMap<String, WebCliContext> contextMap = new ConcurrentHashMap<>();
    private final ConcurrentMap<String, ClosedContext> closedRunners = new ConcurrentHashMap<>();
+   private String hostname = "localhost";
    private int port = 8090;
    private boolean ssl = false;
 
@@ -224,7 +224,7 @@ public class WebCLI extends HyperfoilCli implements Handler<ServerWebSocket> {
       WebsocketOutputStream stream = new WebsocketOutputStream(webSocket);
 
       WebCliContext ctx = new WebCliContext(vertx, inputStream, stream, webSocket);
-      ctx.setClient(new RestClient(vertx, "localhost", port, ssl, true, null));
+      ctx.setClient(new RestClient(vertx, hostname, port, ssl, true, null));
       ctx.setOnline(true);
 
       try {
@@ -286,7 +286,8 @@ public class WebCLI extends HyperfoilCli implements Handler<ServerWebSocket> {
       return commands;
    }
 
-   public void setConnectionOptions(int port, boolean ssl) {
+   public void setConnectionOptions(String hostname, int port, boolean ssl) {
+      this.hostname = hostname;
       this.port = port;
       this.ssl = ssl;
    }


### PR DESCRIPTION
This change allows the web cli to work properly when the controller host name is not localhost. It was always binding to localhost which would fail in this case.