### PR TITLE
Throw exception for misconfigured multi-host HTTP benchmark

### DIFF
--- a/http/src/main/java/io/hyperfoil/http/config/HttpPluginBuilder.java
+++ b/http/src/main/java/io/hyperfoil/http/config/HttpPluginBuilder.java
@@ -17,8 +17,8 @@ import io.hyperfoil.api.config.PluginConfig;
 
 public class HttpPluginBuilder extends PluginBuilder<HttpErgonomics> {
    private HttpBuilder defaultHttp;
-   private List<HttpBuilder> httpList = new ArrayList<>();
-   private HttpErgonomics ergonomics = new HttpErgonomics(this);
+   private final List<HttpBuilder> httpList = new ArrayList<>();
+   private final HttpErgonomics ergonomics = new HttpErgonomics(this);
 
    public HttpPluginBuilder(BenchmarkBuilder parent) {
       super(parent);
@@ -103,7 +103,8 @@ public class HttpPluginBuilder extends PluginBuilder<HttpErgonomics> {
    }
 
    public boolean validateAuthority(String authority) {
-      return authority == null && defaultHttp != null || isValidAuthority(authority);
+      if (authority == null) return defaultHttp != null;
+      return isValidAuthority(authority);
    }
 
    private boolean isValidAuthority(String authority) {


### PR DESCRIPTION
Throw an exception for an HTTP benchmark with multi-hosts where the step doesn't define which host to run. It seems this check was the intended behavior.

However, I think it would be nice to make this "pinning" to a host optional. Otherwise, we would need to define the steps for each host. I'll open this first PR to make sure the exception is thrown and later look at how it is done on Hot Rod to handle the multi-hosts. And if it makes sense, we can update in a follow-up.