### PR TITLE
Check if cache defined for Hot Rod benchmark

### DIFF
--- a/core/src/test/java/io/hyperfoil/core/session/BaseBenchmarkParserTest.java
+++ b/core/src/test/java/io/hyperfoil/core/session/BaseBenchmarkParserTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.Map;
 
 import io.hyperfoil.api.config.Benchmark;
 import io.hyperfoil.core.parser.BenchmarkParser;
@@ -31,4 +32,7 @@ public abstract class BaseBenchmarkParserTest {
       return BenchmarkParser.instance().buildBenchmark(config, TestUtil.benchmarkData(), Collections.emptyMap());
    }
 
+   protected Benchmark loadBenchmark(InputStream config, Map<String, String> arguments) throws IOException, ParserException {
+      return BenchmarkParser.instance().buildBenchmark(config, TestUtil.benchmarkData(), arguments);
+   }
 }

--- a/hotrod/src/main/java/io/hyperfoil/hotrod/connection/HotRodRemoteCachePoolImpl.java
+++ b/hotrod/src/main/java/io/hyperfoil/hotrod/connection/HotRodRemoteCachePoolImpl.java
@@ -7,7 +7,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
-import io.netty.channel.socket.SocketChannel;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.TransportFactory;
@@ -20,6 +19,7 @@ import io.hyperfoil.hotrod.api.HotRodRemoteCachePool;
 import io.hyperfoil.hotrod.config.HotRodCluster;
 import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
 
 public class HotRodRemoteCachePoolImpl implements HotRodRemoteCachePool {
 
@@ -80,7 +80,11 @@ public class HotRodRemoteCachePoolImpl implements HotRodRemoteCachePool {
 
    @Override
    public RemoteCacheWithoutToString<?, ?> getRemoteCache(String cacheName) {
-      return new RemoteCacheWithoutToString(this.remoteCaches.get(cacheName));
+      RemoteCache<?, ?> cache = this.remoteCaches.get(cacheName);
+      if (cache == null) {
+         throw new IllegalArgumentException(String.format("Cache '%s' is not a defined cache", cacheName));
+      }
+      return new RemoteCacheWithoutToString<>(cache);
    }
 
    /*
@@ -90,8 +94,8 @@ public class HotRodRemoteCachePoolImpl implements HotRodRemoteCachePool {
     * This prevent us of configuring each IDE in order to debug a code
     */
    public static class RemoteCacheWithoutToString<K, V> {
-      private RemoteCache<K, V> remoteCache;
-      public RemoteCacheWithoutToString(RemoteCache remoteCache) {
+      private final RemoteCache<K, V> remoteCache;
+      public RemoteCacheWithoutToString(RemoteCache<K, V> remoteCache) {
          this.remoteCache = remoteCache;
       }
 

--- a/hotrod/src/test/java/io/hyperfoil/hotrod/HotRodTest.java
+++ b/hotrod/src/test/java/io/hyperfoil/hotrod/HotRodTest.java
@@ -1,8 +1,11 @@
 package io.hyperfoil.hotrod;
 
+import static org.infinispan.commons.test.Exceptions.assertException;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.io.InputStream;
 import java.util.Map;
 
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -31,6 +34,17 @@ public class HotRodTest extends BaseHotRodTest {
       Map<String, StatisticsSnapshot> stats = runScenario(benchmark);
       assertTrue(stats.get("example").requestCount > 0);
       assertEquals(0, stats.get("example").connectionErrors);
+   }
+
+   @Test
+   public void testUndefinedCache() throws Exception {
+      try (InputStream is = getClass().getClassLoader().getResourceAsStream("scenarios/HotRodPutTest.hf.yaml")) {
+         String cacheName = "something-else-undefined";
+         Benchmark benchmark = loadBenchmark(is, Map.of("CACHE", cacheName, "PORT", String.valueOf(hotrodServers[0].getPort())));
+
+         RuntimeException e = assertThrows(RuntimeException.class, () -> runScenario(benchmark));
+         assertException(RuntimeException.class, IllegalArgumentException.class, String.format("Cache '%s' is not a defined cache", cacheName), e);
+      }
    }
 
    @Override

--- a/hotrod/src/test/resources/scenarios/HotRodPutTest.hf.yaml
+++ b/hotrod/src/test/resources/scenarios/HotRodPutTest.hf.yaml
@@ -2,7 +2,7 @@ name: hotrod-example
 hotrod:
 - uri: !concat [ "hotrod://localhost:", !param PORT 11222 ]
   caches:
-  - my-cache
+  - !param CACHE my-cache
 usersPerSec: 1
 duration: 5s
 scenario:
@@ -10,6 +10,6 @@ scenario:
   - randomInt: cacheKey <- 1 .. 999
   - randomUUID: cacheValue
   - hotrodRequest:
-      put: my-cache
+      put: !param CACHE my-cache
       key: key-${cacheKey}
       value: value-${cacheValue}


### PR DESCRIPTION
Small fix to something I found with a misconfiguration. I didn't have the cache created on the ISPN server. This results in:

```java
21:59:22,606 ERROR (epollEventLoopGroup-3-1) [i.h.a.s.SequenceInstance] #11 phase rampupGet, seq getData[0] failure invoking step hotRodRequest java.lang.NullPointerException: Cannot invoke "shaded.org.infinispan.client.hotrod.RemoteCache.getAsync(Object)" because "this.remoteCache" is null
    at io.hyperfoil.hotrod.connection.HotRodRemoteCachePoolImpl$RemoteCacheWithoutToString.getAsync(HotRodRemoteCachePoolImpl.java:103)
    at io.hyperfoil.hotrod.steps.HotRodRequestStep.invoke(HotRodRequestStep.java:70)
    at io.hyperfoil.api.session.SequenceInstance.progress(SequenceInstance.java:33)
    at io.hyperfoil.core.session.SessionImpl.runSession(SessionImpl.java:279)
    at io.hyperfoil.core.session.SessionImpl.run(SessionImpl.java:233)
    at io.hyperfoil.core.session.SessionImpl.deferredStart(SessionImpl.java:360)
    at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
    at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:416)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.base/java.lang.Thread.run(Thread.java:1583)
```

And on the CLI:

```text
[hyperfoil@localhost]$ run
Started run 0007
Run 0007, benchmark hotrod-reads
Agents: in-vm[STOPPED]
Started: 2024/04/26 22:34:53.909    Terminated: 2024/04/26 22:34:53.947
NAME       STATUS      STARTED       REMAINING  COMPLETED     TOTAL DURATION             DESCRIPTION
load       TERMINATED  22:34:53.909             22:34:53.923  14 ms (exceeded by 15 ms)  1 users at once
rampupGet  TERMINATED  22:34:53.914             22:34:53.946  32 ms                      2.00 - 200.00 users per second
1 phases were cancelled.
Errors:
in-vm: Cannot invoke "shaded.org.infinispan.client.hotrod.RemoteCache.getAsync(Object)" because "this.remoteCache" is null
in-vm: Cannot invoke "shaded.org.infinispan.client.hotrod.RemoteCache.putAsync(Object, Object)" because "this.remoteCache" is null
```

After the changes:

```text
[hyperfoil@localhost]$ run
Started run 0008
Run 0008, benchmark hotrod-reads
Agents: in-vm[STOPPED]
Started: 2024/04/26 22:38:10.475    Terminated: 2024/04/26 22:38:10.877
NAME       STATUS      STARTED       REMAINING  COMPLETED     TOTAL DURATION             DESCRIPTION
load       TERMINATED  22:38:10.476             22:38:10.486  10 ms (exceeded by 11 ms)  1 users at once               
rampupGet  TERMINATED  22:38:10.480             22:38:10.876  396 ms                     2.00 - 200.00 users per second
1 phases were cancelled.
Errors:
in-vm: Cache 'manual' is not a defined cache
in-vm: Cache 'manual' is not a defined cache
```