### PR TITLE
Disable automatic report opening with --silent option

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/Report.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Report.java
@@ -24,6 +24,9 @@ public class Report extends BaseRunIdCommand {
    @Option(shortName = 'y', description = "Assume yes for all interactive questions.", hasValue = false)
    public boolean assumeYes;
 
+   @Option(description = "Do not open the HTML report automatically", hasValue = false)
+   public boolean silent;
+
    @Override
    public CommandResult execute(HyperfoilCommandInvocation invocation) throws CommandException {
       Client.RunRef runRef = getRunRef(invocation);
@@ -60,7 +63,7 @@ public class Report extends BaseRunIdCommand {
          return CommandResult.FAILURE;
       }
       invocation.println("Written to " + destination);
-      if (!"true".equalsIgnoreCase(System.getenv("HYPERFOIL_CONTAINER"))) {
+      if (!"true".equalsIgnoreCase(System.getenv("HYPERFOIL_CONTAINER")) && !silent) {
          openInBrowser("file://" + destination);
       }
       return CommandResult.SUCCESS;


### PR DESCRIPTION
Fixes https://github.com/Hyperfoil/Hyperfoil/issues/344

As first proposal I named the new option `--silent` without short version.

I tested it locally by starting `./distribution/target/distribution/bin/cli.sh` and running:
```bash
report 0000 --destination=/tmp --assumeYes --silent
```

here the result:
![image](https://github.com/Hyperfoil/Hyperfoil/assets/26715795/af6e215c-e473-4271-badb-6f0d6b6941a2)

Without the `--silent` option the behavior is the default one:
![image](https://github.com/Hyperfoil/Hyperfoil/assets/26715795/26a3062f-6576-47e5-8318-7d46d0c25cec)

I am not aware of any unit test for these kind CLI-related changes, if I missed something lmk :pray: 
