### PR TITLE
Remove java.net.preferIPv4Stack=true (Fixes #346)

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -159,7 +159,6 @@
                     <arguments>
                         <argument>-cp</argument>
                         <classpath />
-                        <argument>-Djava.net.preferIPv4Stack=true</argument>
                         <argument>-Dio.hyperfoil.clustered=${io.hyperfoil.clustered}</argument>
                         <argument>${io.hyperfoil.debug}</argument>
                         <argument>io.hyperfoil.boot.Hyperfoil.Controller</argument>

--- a/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployedAgent.java
+++ b/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployedAgent.java
@@ -207,7 +207,6 @@ public class SshDeployedAgent implements DeployedAgent {
          }
       }
 
-      startAgentCommmand.append(" -Djava.net.preferIPv4Stack=true");
       startAgentCommmand.append(" -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory");
       startAgentCommmand.append(" -D").append(Properties.AGENT_NAME).append('=').append(name);
       startAgentCommmand.append(" -D").append(Properties.RUN_ID).append('=').append(runId);

--- a/distribution/src/main/resources/parse-opts.sh
+++ b/distribution/src/main/resources/parse-opts.sh
@@ -53,7 +53,6 @@ if [ -n "$LOG_FILE" ]; then
 fi
 JAVA_OPTS="$JAVA_OPTS $LOG_OPTS \
    --add-opens java.base/java.lang=ALL-UNNAMED \
-   -Djava.net.preferIPv4Stack=true \
    -Dio.hyperfoil.distdir=$ROOT"
 
 # Code taken from https://stackoverflow.com/questions/7334754/correct-way-to-check-java-version-from-bash-script

--- a/k8s-deployer/src/main/java/io/hyperfoil/deploy/k8s/K8sDeployer.java
+++ b/k8s-deployer/src/main/java/io/hyperfoil/deploy/k8s/K8sDeployer.java
@@ -219,7 +219,6 @@ public class K8sDeployer implements Deployer {
       }
 
 
-      command.add("-Djava.net.preferIPv4Stack=true");
       command.add("-Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.Log4j2LogDelegateFactory");
       command.add("-D" + Properties.AGENT_NAME + "=" + agent.name);
       command.add("-D" + Properties.RUN_ID + "=" + runId);

--- a/test-suite/pom.xml
+++ b/test-suite/pom.xml
@@ -96,9 +96,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludedGroups>${junit.excluded.categories}</excludedGroups>
-                    <systemPropertyVariables>
-                        <java.net.preferIPv4Stack>true</java.net.preferIPv4Stack>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This option is no longer needed and enable IP v6 users on Hyperfoil to have OOTB support.