### PR TITLE
Add automated backporting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->
+
+## Fixes Issue
+
+<!-- Remove this section if not applicable -->
+
+<!-- Example: Fixes #31 -->
+
+## Changes proposed
+
+<!-- List all the proposed changes in your PR -->
+
+<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
+<!--
+- [x] Correct; marked as done
+- [X] Correct; marked as done
+
+- [ ] Not correct; marked as **not** done
+-->
+
+## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->
+
+- [ ] My change requires changes to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] All new and existing tests passed.
+
+> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 
+
+<details>
+<summary>
+How to backport a pull request to the current <em>stable</em> branch?
+</summary>
+
+In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.
+
+Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.
+
+> The `backport` label can be also added after the pull  request has been merged.
+
+> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
+</details>

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,53 @@
+# Workflow that automate the pull request backporting process
+# Simply labeling the PR with `backport` label will automatically
+# create the backporting PR as soon as the original one is merged
+name: Pull Request Backporting using Git Backporting
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NO_SQUASH_OPTION: true
+
+jobs:
+  backporting:
+    name: "Backporting"
+    concurrency:
+        group: backporting-${{ github.head_ref }}
+        cancel-in-progress: true
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+          && (contains(github.event.pull_request.labels.*.name, 'backport')
+            || contains(github.event.pull_request.labels.*.name, 'backport-squash'))
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Override no-squash option
+        if: >
+          (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'backport-squash'))
+          || (github.event.action == 'labeled' && contains(github.event.label.name, 'backport-squash'))
+        shell: bash
+        run: |
+          echo "NO_SQUASH_OPTION=false" >> $GITHUB_ENV
+      - name: Backporting
+        uses: kiegroup/git-backporting@v4
+        with:
+          target-branch: 0.26.x
+          pull-request: ${{ github.event.pull_request.url }}
+          auth: ${{ secrets.RH_PERF_BOT_TOKEN }}
+          no-squash: ${{ env.NO_SQUASH_OPTION }}
+          strategy: ort
+          strategy-option: ours
+          enable-err-notification: true


### PR DESCRIPTION
**Changes**

- Add automated backporting GitHub workflow.
- Add pull request template

**How does backporting work?**

As soon as a release is rolled out, we create a stable branch, e.g., for version `0.26` we created stable branch `0.26.x`.
Stable branches are used to roll out bug fixing releases, e.g., `0.26.1`.

This means that some changes, especially bug fixes need to be applied on `master` branch as well as on the current _stable_ one. In order to make this process easier, the **backporting** workflow comes to the rescue: pull requests _should_ target the `master` branch (unless the issue is no more present there), if the change should be applied to the stable one, simply add the `backport` label and as soon as the PR is merged the process will automatically create the backporting PR against the _stable_ branch.
