### PR TITLE
Rate generators refactoring and compensation unification

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -129,6 +129,12 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/core/src/main/java/io/hyperfoil/core/impl/OpenModel.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/OpenModel.java
@@ -1,0 +1,31 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.config.Model;
+import io.hyperfoil.api.config.Phase;
+import io.hyperfoil.api.session.PhaseInstance;
+import io.hyperfoil.core.impl.rate.RateGenerator;
+
+final class OpenModel {
+
+   public static PhaseInstance constantRate(Phase def, String runId, int agentId) {
+      var model = (Model.ConstantRate) def.model;
+      double usersPerSec = def.benchmark().slice(model.usersPerSec, agentId);
+      if (model.variance) {
+         return new OpenModelPhase(RateGenerator.poissonConstantRate(usersPerSec), def, runId, agentId);
+      } else {
+         return new OpenModelPhase(RateGenerator.constantRate(usersPerSec), def, runId, agentId);
+      }
+   }
+
+   public static PhaseInstance rampRate(Phase def, String runId, int agentId) {
+      var model = (Model.RampRate) def.model;
+      double initialUsersPerSec = def.benchmark().slice(model.initialUsersPerSec, agentId);
+      double targetUsersPerSec = def.benchmark().slice(model.targetUsersPerSec, agentId);
+      long durationMs = def.duration;
+      if (model.variance) {
+         return new OpenModelPhase(RateGenerator.poissonRampRate(initialUsersPerSec, targetUsersPerSec, durationMs), def, runId, agentId);
+      } else {
+         return new OpenModelPhase(RateGenerator.rampRate(initialUsersPerSec, targetUsersPerSec, durationMs), def, runId, agentId);
+      }
+   }
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/OpenModelPhase.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/OpenModelPhase.java
@@ -1,0 +1,116 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.config.Model;
+import io.hyperfoil.api.config.Phase;
+import io.hyperfoil.api.session.Session;
+import io.hyperfoil.core.impl.rate.FireTimeListener;
+import io.hyperfoil.core.impl.rate.RateGenerator;
+import io.netty.util.concurrent.EventExecutorGroup;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * This is a base class for Open Model phases that need to compensate users based on the available ones in the session pool.
+ * <br>
+ * The notion of being "throttled" users requires some explanation:
+ * <ul>
+ *     <li>a user requires a {@link Session} to run, hence the two terms are used to denote the same concept</li>
+ *     <li>starting a {@link Session} doesn't mean immediate execution, but scheduling a deferred start in the {@link Session#executor()}</li>
+ *     <li>given that {@link Session}s are pooled, being throttled means that no available instances are found by {@link #onFireTimes(long)}</li>
+ *     <li>when a {@link Session} finishes, {@link #notifyFinished(Session)} can immediately restart it if there are
+ *     throttled users, preventing it to be pooled</li>
+ * </ul>
+ * <p>
+ * The last point is crucial because it means that a too small amount of pooled sessions would be "compensated" only
+ * when a session finished, instead of when {@link #sessionPool} has available sessions available.
+ */
+final class OpenModelPhase extends PhaseInstanceImpl implements FireTimeListener {
+
+    private final int maxSessions;
+    private final AtomicLong throttledUsers = new AtomicLong(0);
+    private final RateGenerator rateGenerator;
+    private final long relativeFirstFireTime;
+
+    OpenModelPhase(RateGenerator rateGenerator, Phase def, String runId, int agentId) {
+        super(def, runId, agentId);
+        this.rateGenerator = rateGenerator;
+        this.maxSessions = Math.max(1, def.benchmark().slice(((Model.OpenModel) def.model).maxSessions, agentId));
+        this.relativeFirstFireTime = rateGenerator.lastComputedFireTimeMs();
+    }
+
+    @Override
+    public void reserveSessions() {
+        if (log.isDebugEnabled()) {
+            log.debug("Phase {} reserving {} sessions", def.name, maxSessions);
+        }
+        sessionPool.reserve(maxSessions);
+    }
+
+    @Override
+    protected void proceedOnStarted(final EventExecutorGroup executorGroup) {
+        long elapsedMs = System.currentTimeMillis() - absoluteStartTime;
+        long remainingMsToFirstFireTime = relativeFirstFireTime - elapsedMs;
+        if (remainingMsToFirstFireTime > 0) {
+            executorGroup.schedule(() -> proceed(executorGroup), remainingMsToFirstFireTime, TimeUnit.MILLISECONDS);
+        } else {
+            // we are not enforcing to be called from an event loop thread here, and indeed tests uses the main thread:
+            proceed(executorGroup);
+        }
+    }
+
+    @Override
+    public void proceed(final EventExecutorGroup executorGroup) {
+        if (status.isFinished()) {
+            return;
+        }
+        long realFireTimeMs = System.currentTimeMillis();
+        long elapsedTimeMs = realFireTimeMs - absoluteStartTime;
+        // the time should flow forward: we can have some better check here for NTP and maybe rise a warning
+        assert elapsedTimeMs >= rateGenerator.lastComputedFireTimeMs();
+        long expectedNextFireTimeMs = rateGenerator.computeNextFireTime(elapsedTimeMs, this);
+        // we need to make sure that the scheduling decisions are made based on the current time
+        long rateGenerationDelayMs = System.currentTimeMillis() - realFireTimeMs;
+        assert rateGenerationDelayMs >= 0;
+        // given that both computeNextFireTime and onFireTimes can take some time, we need to adjust the fire time
+        long scheduledFireDelayMs = Math.max(0, (expectedNextFireTimeMs - elapsedTimeMs) - rateGenerationDelayMs);
+        if (trace) {
+            log.trace("{}: {} after start, {} started ({} throttled), next user in {} ms, scheduling decisions tooks {} ms", def.name, elapsedTimeMs,
+                    rateGenerator.fireTimes(), throttledUsers, scheduledFireDelayMs, rateGenerationDelayMs);
+        }
+        if (scheduledFireDelayMs <= 0) {
+            // we're so late that there's no point in bothering the executor with timers
+            executorGroup.execute(() -> proceed(executorGroup));
+        } else {
+            executorGroup.schedule(() -> proceed(executorGroup), scheduledFireDelayMs, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public void onFireTime() {
+        if (!startNewSession()) {
+            throttledUsers.incrementAndGet();
+        }
+    }
+
+    @Override
+    public void notifyFinished(Session session) {
+        if (session != null && !status.isFinished()) {
+            long throttled = throttledUsers.get();
+            while (throttled != 0) {
+                if (throttledUsers.compareAndSet(throttled, throttled - 1)) {
+                    // TODO: it would be nice to compensate response times
+                    // in these invocations for the fact that we're applying
+                    // SUT feedback, but that would be imprecise anyway.
+                    session.start(this);
+                    // this prevents the session to be pooled
+                    return;
+                } else {
+                    throttled = throttledUsers.get();
+                }
+            }
+        }
+        super.notifyFinished(session);
+    }
+
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/BaseRateGenerator.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/BaseRateGenerator.java
@@ -1,0 +1,22 @@
+package io.hyperfoil.core.impl.rate;
+
+public abstract class BaseRateGenerator implements RateGenerator {
+
+    protected double fireTimeMs;
+    protected long fireTimes;
+
+    public BaseRateGenerator() {
+        fireTimeMs = 0;
+    }
+
+    @Override
+    public long fireTimes() {
+        return fireTimes;
+    }
+
+    @Override
+    public long lastComputedFireTimeMs() {
+        return (long) Math.ceil(fireTimeMs);
+    }
+}
+

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/ConstantRateGenerator.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/ConstantRateGenerator.java
@@ -1,0 +1,21 @@
+package io.hyperfoil.core.impl.rate;
+
+final class ConstantRateGenerator extends FunctionalRateGenerator {
+
+    private final double fireTimesPerSec;
+
+    ConstantRateGenerator(final double fireTimesPerSec) {
+        this.fireTimesPerSec = fireTimesPerSec;
+    }
+
+    @Override
+    protected long computeFireTimes(final long elapsedTimeMs) {
+        return (long) (elapsedTimeMs * fireTimesPerSec / 1000);
+    }
+
+    @Override
+    protected double computeFireTimeMs(final long targetFireTimes) {
+        return 1000 * targetFireTimes / fireTimesPerSec;
+    }
+
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/FireTimeListener.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/FireTimeListener.java
@@ -1,0 +1,14 @@
+package io.hyperfoil.core.impl.rate;
+
+@FunctionalInterface
+public interface FireTimeListener {
+
+    void onFireTime();
+
+    default void onFireTimes(long count) {
+        for (long i = 0; i < count; i++) {
+            onFireTime();
+        }
+    }
+
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/FunctionalRateGenerator.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/FunctionalRateGenerator.java
@@ -1,0 +1,21 @@
+package io.hyperfoil.core.impl.rate;
+
+public abstract class FunctionalRateGenerator extends BaseRateGenerator {
+    protected abstract long computeFireTimes(long elapsedTimeMs);
+
+    protected abstract double computeFireTimeMs(long targetFireTimes);
+
+    @Override
+    public long computeNextFireTime(final long elapsedTimeMs, FireTimeListener listener) {
+        if (elapsedTimeMs < fireTimeMs) {
+            return (long) Math.ceil(fireTimeMs);
+        }
+        final long fireTimes = computeFireTimes(elapsedTimeMs) + 1;
+        final double nextFireTimeMs = computeFireTimeMs(fireTimes);
+        fireTimeMs = nextFireTimeMs;
+        long missingFireTimes = fireTimes - this.fireTimes;
+        this.fireTimes = fireTimes;
+        listener.onFireTimes(missingFireTimes);
+        return (long) Math.ceil(nextFireTimeMs);
+    }
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/PoissonConstantRateGenerator.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/PoissonConstantRateGenerator.java
@@ -1,0 +1,50 @@
+package io.hyperfoil.core.impl.rate;
+
+import java.util.Random;
+
+/**
+ * This generator is computing the time for the next event to be scheduled in order that the total events
+ * follow a homogeneous Poisson process.<br><br>
+ * Given this formula to compute the next fire time based on the previous one<br><br>
+ * <code>fireTime(t) = fireTime(t -1) + T</code><br><br>
+ * {@code T} is a random variable that follows an exponential distribution with rate {@code fireTimesPerSec}.<br><br>
+ * The formula to compute the next fire time is:<br><br>
+ * <code>fireTime(t) = fireTime(t -1) + -log(rand) / fireTimesPerSec</code><br><br>
+ * where the T part (exponential distribution) is computed as {@code -log(rand) / fireTimesPerSec}
+ * and uses the <a href="https://en.wikipedia.org/wiki/Inverse_transform_sampling">inverse transform sampling method<a/>
+ * to generate such intervals following an exponential distribution.<br><br>
+ * Specifically, the exponential distribution is defined as:<br><br>
+ * <code>f(x) = fireTimesPerSec * exp(-fireTimesPerSec * x)</code><br><br>
+ * where {@code x} is the random variable and {@code fireTimesPerSec} is the rate of the distribution.<br><br>
+ * In order to generate samples which follow it we need to compute the inverse function of the cumulative distribution function (CDF).<br><br>
+ * The CDF of the exponential distribution is obtained by integrating the probability density function (PDF) from 0 to {@code x} and is defined as:<br><br>
+ * <code>F(x) = 1 - exp(-fireTimesPerSec * x)</code><br><br>
+ * We can transform this function by performing the logarithm of both sides:<br><br>
+ * <code>log(1 - F(x)) = -fireTimesPerSec * x</code><br><br>
+ * Resolving the previous equation for {@code x} we get:<br><br>
+ * <code>x = -log(1 - F(x)) / fireTimesPerSec</code><br><br>
+ * But given that {@code F(x)} is a random variable that follows a uniform distribution between 0 and 1, {@code 1 - F(x)}
+ * is also a random variable that follows a uniform distribution between 0 and 1.<br><br>
+ * Therefore, the formula to generate samples that follow an exponential distribution is:<br><br>
+ * <code>x = -log(rand) / fireTimesPerSec</code><br><br>
+ * which is the inverse function of the CDF of the exponential distribution and {@code x} is a random variable
+ * that follows a uniform distribution between 0 and 1.<br><br>
+ */
+final class PoissonConstantRateGenerator extends SequentialRateGenerator {
+
+    private final Random random;
+    private final double fireTimesPerSec;
+
+    PoissonConstantRateGenerator(final Random random, final double fireTimesPerSec) {
+        this.random = random;
+        this.fireTimesPerSec = fireTimesPerSec;
+        this.fireTimeMs = nextFireTimeMs(0);
+    }
+
+    @Override
+    protected double nextFireTimeMs(final double elapsedTimeMs) {
+        // the Math.max(1e-20, random.nextDouble()) is to prevent the logarithm to be negative infinity, because
+        // the random number can approach to 0 and the logarithm of 0 is negative infinity
+        return elapsedTimeMs + 1000 * -Math.log(Math.max(1e-20, random.nextDouble())) / fireTimesPerSec;
+    }
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/PoissonRampRateGenerator.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/PoissonRampRateGenerator.java
@@ -1,0 +1,81 @@
+package io.hyperfoil.core.impl.rate;
+
+import java.util.Random;
+
+/**
+ * This generator is computing the time for the next event to be scheduled in order that the total events
+ * follow a non-homogeneous Poisson process with a linearly increasing rate.<br>
+ * Similarly to {@link PoissonConstantRateGenerator}, the generator is computing the time for the next event
+ * to be scheduled based on the previous one, but the inverse transform sampling method to produce samples
+ * depends on rate(t) instead of a constant rate i.e. fireTimesPerSec.<br>
+ * Such function is defined as:<br>
+ * {@code T = -log(rand) / rate(t)}<br>
+ * The rate function <code>rate(t)</code> is a linear function of time, defined as:<br>
+ * <code>rate(t) = initialFireTimesPerSec + (targetFireTimesPerSec - initialFireTimesPerSec) * (elapsedTimeMs / durationMs)</code><br>
+ * To compute the time interval {@code T} until the next event, we need to solve the integral equation that accounts for the non-homogeneous Poisson process with a time-varying rate function.<br>
+ * The process can be broken down as follows:
+ * <ol>
+ *     <li>Since {@code rate(t)} is not constant but changes linearly over time, we need to consider the integration of the rate function over the interval [0, T].
+ *         <br>
+ *         Intuitively, we can look back at the previous formula {@code T = -log(rand) / rate(t)} as {@code rate(t) * T = -log(rand)} where {@code rate(t) * T} are the number of
+ *         fire times in the period T.<br>
+ *         This information can be obtained as the area of the rate(t) function from 0 to T, which is the mentioned integral.<br><br>
+ *         The integral equation is:
+ *         {@code ∫[0 to T] (initialFireTimesPerSec + (targetFireTimesPerSec - initialFireTimesPerSec) * (t / durationMs)) dt = -log(rand)}
+ *     </li>
+ *     <li>The left-hand side of the equation is:
+ *         <br>
+ *         {@code (initialFireTimesPerSec * T) + ((targetFireTimesPerSec - initialFireTimesPerSec) * T^2) / (2 * durationMs)}
+ *     </li>
+ *     <li>Set this equal to {@code -log(rand)} and solve for {@code T}:
+ *         <br>
+ *         {@code initialFireTimesPerSec * T + ((targetFireTimesPerSec - initialFireTimesPerSec) * T^2) / (2 * durationMs) = -log(rand)}
+ *     </li>
+ *     <li>This is a quadratic equation of the form:
+ *         <br>
+ *         {@code aT^2 + bT + c = 0}
+ *         <br>
+ *         where:
+ *         <ul>
+ *             <li>{@code a = (targetFireTimesPerSec - initialFireTimesPerSec) / (2 * durationMs)}</li>
+ *             <li>{@code b = initialFireTimesPerSec}</li>
+ *             <li>{@code c = -log(rand)}</li>
+ *         </ul>
+ *     </li>
+ *     <li>Use the quadratic formula to solve for {@code T}:
+ *         <br>
+ *         {@code T = (-b ± sqrt(b^2 - 4ac)) / (2a)}
+ *     </li>
+ *     <li>Since time intervals cannot be negative, choose the positive root:
+ *         <br>
+ *         {@code T = (-initialFireTimesPerSec + sqrt(initialFireTimesPerSec^2 - 4 * (targetFireTimesPerSec - initialFireTimesPerSec) * (-log(rand) / (2 * durationMs)))) / ((targetFireTimesPerSec - initialFireTimesPerSec) / durationMs)}
+ *     </li>
+ *     <li>Simplify the expression to get the value of {@code T}.
+ *         <br>
+ *         The result is the time interval {@code T} for the next event to be scheduled. Add this interval to the current elapsed time.
+ *     </li>
+ * </ol>
+ */
+final class PoissonRampRateGenerator extends SequentialRateGenerator {
+
+    private final double initialFireTimesPerSec;
+    private final Random random;
+    private final long duration;
+    private final double aCoef;
+
+    PoissonRampRateGenerator(final Random random, final double initialFireTimesPerSec, final double targetFireTimesPerSec, final long durationMs) {
+        this.initialFireTimesPerSec = initialFireTimesPerSec;
+        this.duration = durationMs;
+        this.aCoef = (targetFireTimesPerSec - initialFireTimesPerSec);
+        this.random = random;
+        fireTimeMs = nextFireTimeMs(0);
+    }
+
+    @Override
+    protected double nextFireTimeMs(final double elapsedTimeMs) {
+        // we're solving quadratic equation coming from t = (duration * -log(rand))/(((t + now) * (target - initial)) + initial * duration)
+        final double bCoef = elapsedTimeMs * aCoef + initialFireTimesPerSec * duration;
+        final double cCoef = duration * 1000 * Math.log(random.nextDouble());
+        return elapsedTimeMs + (-bCoef + Math.sqrt(bCoef * bCoef - 4 * aCoef * cCoef)) / (2 * aCoef);
+    }
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/RampRateGenerator.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/RampRateGenerator.java
@@ -1,0 +1,53 @@
+package io.hyperfoil.core.impl.rate;
+
+
+/**
+ * This is a generator that generates events (fire times) at a ramping rate.
+ * The rate of events starts at an initial rate and increases linearly to a target rate over a specified duration.
+ * <p>
+ * The rate function is a linear function of time, defined as:
+ * <pre>{@code
+ * rate(t) = initialFireTimesPerSec + (targetFireTimesPerSec - initialFireTimesPerSec) * (elapsedTimeMs / durationMs)
+ * }</pre>
+ * To find the required number of events at time t, we need to integrate the rate function from 0 to t:
+ * <pre>{@code
+ * requiredFireTimes(t) = ∫[0 to t] (initialFireTimesPerSec + (targetFireTimesPerSec - initialFireTimesPerSec) * (t / durationMs)) dt
+ * }</pre>
+ * Which simplifies to:
+ * <pre>{@code
+ * requiredFireTimes(t) = (initialFireTimesPerSec * t) + ((targetFireTimesPerSec - initialFireTimesPerSec) * t^2) / (2 * durationMs)
+ * }</pre>
+ * Given the elapsed time {@code t} we can use the above formula to compute the required number of events.<br>
+ * To obtain the next fire time, we need to solve the integral equation for the required number of events at time t.<br>
+ * Assuming the required number of events at time t is known (using the previous formula and adding another one),
+ * we can resolve the previous equation for t rearranging it into a quadratic equation of the form aT^2 + bT + c = 0.<br>
+ * <p>
+ * Let:
+ * <ul>
+ *     <li>{@code a = (targetFireTimesPerSec - initialFireTimesPerSec) / (2 * durationMs)}</li>
+ *     <li>{@code b = initialFireTimesPerSec}</li>
+ *     <li>{@code c = -requiredFireTimes(t)}</li>
+ * </ul>
+ * Solving this quadratic equation for {@code t} provides the time at which the next event should be scheduled.
+ */
+final class RampRateGenerator extends FunctionalRateGenerator {
+
+    private final double bCoef;
+    private final double progress;
+
+    RampRateGenerator(final double initialFireTimesPerSec, final double targetFireTimesPerSec, final long durationMs) {
+        bCoef = initialFireTimesPerSec / 1000;
+        progress = (targetFireTimesPerSec - initialFireTimesPerSec) / (durationMs * 1000);
+    }
+
+    @Override
+    protected long computeFireTimes(final long elapsedTimeMs) {
+        return (long) ((progress * elapsedTimeMs / 2 + bCoef) * elapsedTimeMs);
+    }
+
+    @Override
+    protected double computeFireTimeMs(final long targetFireTimes) {
+        // root of quadratic equation
+        return Math.ceil((-bCoef + Math.sqrt(bCoef * bCoef + 2 * progress * targetFireTimes)) / progress);
+    }
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/RateGenerator.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/RateGenerator.java
@@ -1,0 +1,42 @@
+package io.hyperfoil.core.impl.rate;
+
+import java.util.Random;
+
+public interface RateGenerator {
+
+    long computeNextFireTime(long elapsedMillis, FireTimeListener listener);
+
+    long lastComputedFireTimeMs();
+
+    long fireTimes();
+
+    static RateGenerator constantRate(double fireTimesPerSec) {
+        return new ConstantRateGenerator(fireTimesPerSec);
+    }
+
+    static RateGenerator rampRate(double initialFireTimesPerSec, double targetFireTimesPerSec, long durationMs) {
+        if (Math.abs(targetFireTimesPerSec - initialFireTimesPerSec) < 0.000001) {
+            return constantRate(initialFireTimesPerSec);
+        }
+        return new RampRateGenerator(initialFireTimesPerSec, targetFireTimesPerSec, durationMs);
+    }
+
+    static RateGenerator poissonConstantRate(Random random, double usersPerSec) {
+        return new PoissonConstantRateGenerator(random, usersPerSec);
+    }
+
+    static RateGenerator poissonConstantRate(double usersPerSec) {
+        return poissonConstantRate(new Random(), usersPerSec);
+    }
+
+    static RateGenerator poissonRampRate(Random random, double initialFireTimesPerSec, double targetFireTimesPerSec, long durationMs) {
+        if (Math.abs(targetFireTimesPerSec - initialFireTimesPerSec) < 0.000001) {
+            return poissonConstantRate(random, initialFireTimesPerSec);
+        }
+        return new PoissonRampRateGenerator(random, initialFireTimesPerSec, targetFireTimesPerSec, durationMs);
+    }
+
+    static RateGenerator poissonRampRate(double initialFireTimesPerSec, double targetFireTimesPerSec, long durationMs) {
+        return poissonRampRate(new Random(), initialFireTimesPerSec, targetFireTimesPerSec, durationMs);
+    }
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/rate/SequentialRateGenerator.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/rate/SequentialRateGenerator.java
@@ -1,0 +1,20 @@
+package io.hyperfoil.core.impl.rate;
+
+abstract class SequentialRateGenerator extends BaseRateGenerator {
+
+    protected abstract double nextFireTimeMs(double elapsedTimeMs);
+
+    @Override
+    public final long computeNextFireTime(final long elapsedTimeMs, FireTimeListener listener) {
+        long fireTimesToMillis = 0;
+        double nextFireTimeMs = fireTimeMs;
+        while (elapsedTimeMs >= nextFireTimeMs) {
+            listener.onFireTime();
+            fireTimesToMillis++;
+            nextFireTimeMs = nextFireTimeMs(nextFireTimeMs);
+        }
+        fireTimeMs = nextFireTimeMs;
+        this.fireTimes += fireTimesToMillis;
+        return (long) Math.ceil(nextFireTimeMs);
+    }
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/rate/ConstantRateGeneratorTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/rate/ConstantRateGeneratorTest.java
@@ -1,0 +1,23 @@
+package io.hyperfoil.core.impl.rate;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConstantRateGeneratorTest extends RateGeneratorTest {
+   @Override
+   int samples() {
+      return 1000;
+   }
+
+   @Override
+   RateGenerator newUserGenerator() {
+      return RateGenerator.constantRate(1000);
+   }
+
+   @Override
+   void assertSamplesWithoutSkew(final double[] samples, final long totalUsers) {
+      for (int i = 1; i < samples.length; ++i) {
+         assertEquals(samples[i - 1] + 1.0, samples[i], 0.0);
+      }
+      assertEquals(999, samples[samples.length - 1] - samples[0], 0.0);
+   }
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/rate/DecreasingRumpRateGeneratorTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/rate/DecreasingRumpRateGeneratorTest.java
@@ -1,0 +1,23 @@
+package io.hyperfoil.core.impl.rate;
+
+import static org.junit.Assert.assertEquals;
+
+public class DecreasingRumpRateGeneratorTest extends RateGeneratorTest {
+
+   @Override
+   int samples() {
+      // this is using the math series sum formula to calculate the total number of users i.e. sum(1, m) = m * (1 + m) / 2
+      // total_users := 10 * (1 + 10) / 2 = 55
+      return 55;
+   }
+
+   @Override
+   RateGenerator newUserGenerator() {
+      return RateGenerator.rampRate(10, 1, 10_000);
+   }
+
+   @Override
+   void assertSamplesWithoutSkew(final double[] samples, final long totalUsers) {
+      assertEquals(10_000, samples[samples.length - 1], 0.0);
+   }
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/rate/FireTimesCounter.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/rate/FireTimesCounter.java
@@ -1,0 +1,15 @@
+package io.hyperfoil.core.impl.rate;
+
+final class FireTimesCounter implements FireTimeListener {
+
+   public long fireTimes;
+
+   FireTimesCounter() {
+      fireTimes = 0;
+   }
+
+   @Override
+   public void onFireTime() {
+      fireTimes++;
+   }
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/rate/PoissonConstantRateGeneratorTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/rate/PoissonConstantRateGeneratorTest.java
@@ -1,0 +1,29 @@
+package io.hyperfoil.core.impl.rate;
+
+import java.util.Random;
+
+public class PoissonConstantRateGeneratorTest extends RateGeneratorTest {
+
+   private static final int SEED = 0;
+
+   @Override
+   int samples() {
+      return 1_000;
+   }
+
+   @Override
+   RateGenerator newUserGenerator() {
+      // force the Random::nextDouble to return 0.5
+      return RateGenerator.poissonConstantRate(new Random(SEED), 1000);
+   }
+
+   @Override
+   public void assertSamplesWithoutSkew(final double[] samples, final long totalUsers) {
+      // Perform K-S test
+      final double[] interArrivalTimes = computeInterArrivalTimes(samples);
+      // it is important to use the same SEED here!
+      kolmogorovSmirnovTestVsExpDistr(interArrivalTimes, SEED, 1.0);
+   }
+
+
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/rate/PoissonRampRateGeneratorTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/rate/PoissonRampRateGeneratorTest.java
@@ -1,0 +1,36 @@
+package io.hyperfoil.core.impl.rate;
+
+import java.util.Random;
+
+public class PoissonRampRateGeneratorTest extends RateGeneratorTest {
+
+   private static final int SEED = 0;
+
+   private static double computeRateAtTime(final double initialRate, final double targetRate, final long duration, final double currentTime) {
+      return initialRate + (targetRate - initialRate) * (currentTime / duration);
+   }
+
+   @Override
+   int samples() {
+      return 1000;
+   }
+
+   @Override
+   RateGenerator newUserGenerator() {
+      return RateGenerator.poissonRampRate(new Random(SEED), 1, 10, 10000);
+   }
+
+   @Override
+   void assertSamplesWithoutSkew(final double[] samples, final long totalUsers) {
+      final double[] interArrivalTimes = computeInterArrivalTimes(samples);
+      final double[] fireTimesOnIntervals = new double[interArrivalTimes.length];
+      double elapsedTime = 0;
+      for (int i = 0; i < interArrivalTimes.length; i++) {
+         final double rpMs = computeRateAtTime(0.001, 0.01, 10000, elapsedTime);
+         fireTimesOnIntervals[i] = interArrivalTimes[i] * rpMs;
+         elapsedTime += interArrivalTimes[i];
+      }
+      // fireTimesOnIntervals should follow an exponential distribution with lambda = 1
+      kolmogorovSmirnovTestVsExpDistr(fireTimesOnIntervals, SEED, 1.0);
+   }
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/rate/RampRateRateGeneratorTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/rate/RampRateRateGeneratorTest.java
@@ -1,0 +1,59 @@
+package io.hyperfoil.core.impl.rate;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RampRateRateGeneratorTest extends RateGeneratorTest {
+
+   private static double computeRateAtTime(final double initialRate, final double targetRate, final long duration, final double currentTime) {
+      return initialRate + (targetRate - initialRate) * (currentTime / duration);
+   }
+
+   @Override
+   int samples() {
+      // this is using the math series sum formula to calculate the total number of users i.e. sum(1, m) = m * (1 + m) / 2
+      // total_users := 10 * (1 + 10) / 2 = 55
+      return 55;
+   }
+
+   @Override
+   RateGenerator newUserGenerator() {
+      return RateGenerator.rampRate(1, 10, 10_000);
+   }
+
+   @Test
+   public void divisionByZeroTest() {
+      final var generator = RateGenerator.rampRate(10, 10, 10_000);
+      final var missingFireTimeCounter = new FireTimesCounter();
+      generator.computeNextFireTime(9999, missingFireTimeCounter);
+      Assert.assertEquals(100, missingFireTimeCounter.fireTimes);
+   }
+
+   @Test
+   public void slowStartTest() {
+      final var generator = newUserGenerator();
+      final var missingFireTimeCounter = new FireTimesCounter();
+      generator.computeNextFireTime(9999, missingFireTimeCounter);
+      Assert.assertEquals(samples(), missingFireTimeCounter.fireTimes);
+   }
+
+   @Override
+   void assertSamplesWithoutSkew(final double[] samples, final long totalUsers) {
+      // compute inter-arrival times
+      final double[] interArrivalTimes = computeInterArrivalTimes(samples);
+      // compute fire times on intervals
+      final double[] fireTimesOnIntervals = new double[interArrivalTimes.length];
+      double elapsedTime = 0;
+      for (int i = 0; i < interArrivalTimes.length; i++) {
+         final double rpMs = computeRateAtTime(1.0 / 1000, 10.0 / 1000, 10_000, elapsedTime);
+         fireTimesOnIntervals[i] = interArrivalTimes[i] * rpMs;
+         elapsedTime += interArrivalTimes[i];
+      }
+      // we expect each of them to be 1.0
+      for (final var fireTime : fireTimesOnIntervals) {
+         assertEquals(1.0, fireTime, 0.0);
+      }
+   }
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/rate/RateGeneratorTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/rate/RateGeneratorTest.java
@@ -1,0 +1,67 @@
+package io.hyperfoil.core.impl.rate;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.math3.distribution.ExponentialDistribution;
+import org.apache.commons.math3.random.JDKRandomGenerator;
+import org.apache.commons.math3.stat.inference.KolmogorovSmirnovTest;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public abstract class RateGeneratorTest {
+
+   public static double[] computeInterArrivalTimes(final double[] samples) {
+      final double[] interArrivalTimes = new double[samples.length - 1];
+      int j = 0;
+      for (int i = 1; i < samples.length; i++) {
+         final double intervalMs = samples[i] - samples[i - 1];
+         interArrivalTimes[j] = intervalMs;
+         j++;
+      }
+      return interArrivalTimes;
+   }
+
+   public static void kolmogorovSmirnovTestVsExpDistr(final double[] data, final int seed, final double mean) {
+      final KolmogorovSmirnovTest ksTest = new KolmogorovSmirnovTest(new JDKRandomGenerator(seed));
+      final ExponentialDistribution expDistribution = new ExponentialDistribution(mean); // Mean of the distribution is 1 for the normalized data
+      final double pValue = ksTest.kolmogorovSmirnovTest(expDistribution, data);
+
+
+      if (pValue < 0.05) {
+         Assert.fail("The generated fire times do not follow the expected exponential distribution. p-value: " + pValue);
+      }
+   }
+
+   abstract int samples();
+
+   abstract RateGenerator newUserGenerator();
+
+   abstract void assertSamplesWithoutSkew(double[] fireTimesMs, long totalUsers);
+
+   @Test
+   public void testNoFireTimesOnCreation() {
+      assertEquals(0, newUserGenerator().fireTimes());
+   }
+
+   @Test
+   @Ignore("This test fail due to lastComputedFireTimeMs() uses Math.ceil() and can skew the results")
+   public void testFireTimesDistributionWithoutSkew() {
+      final int samples = samples();
+      final var fireTimeSamples = new double[samples];
+      final var userGenerator = newUserGenerator();
+      final var fireTimesCounter = new FireTimesCounter();
+      for (int i = 0; i < samples; i++) {
+         final long fireTimesBefore = userGenerator.fireTimes();
+         fireTimesCounter.fireTimes = 0;
+         final var nextFireTimeMs = userGenerator.computeNextFireTime(userGenerator.lastComputedFireTimeMs(), fireTimesCounter);
+         final long fireTimesAfter = userGenerator.fireTimes();
+         assertEquals(1, fireTimesCounter.fireTimes);
+         assertEquals(1, fireTimesAfter - fireTimesBefore);
+         assertEquals(nextFireTimeMs, userGenerator.lastComputedFireTimeMs(), 0.0);
+         fireTimeSamples[i] = nextFireTimeMs;
+      }
+      assertEquals(samples(), userGenerator.fireTimes());
+      assertSamplesWithoutSkew(fireTimeSamples, userGenerator.fireTimes());
+   }
+}


### PR DESCRIPTION
This is required for https://github.com/Hyperfoil/Hyperfoil/issues/342 because there are no tests for not point poisson rate generators, nor unit tests to verify that the rate generators are working as expected.

I'll keep on working on this to add more deterministic tests.

The most relevant change here is the change in the compensation logic at [8c9fa8ef60841d2b60eedd988ab3ed57aeb1610c for the ](https://github.com/Hyperfoil/Hyperfoil/commit/8c9fa8ef60841d2b60eedd988ab3ed57aeb1610c#diff-088ca7616526932d6ec3865d81225f8f40704022d96dacfd1dd461426de4dc7fR34) which unify the fuzzy/precise generators, making the latter to not give up on compensating users when the pool is exhausted and the removal of https://github.com/Hyperfoil/Hyperfoil/commit/8c9fa8ef60841d2b60eedd988ab3ed57aeb1610c#diff-ebe33043584e91c6a83692dedff9dcba583b224468b420c05364e0259a8c1dc1L29 because (unless bugs!) `nextRequiredUsers` should be always bigger than `startedOrThrottledUsers` and the delta is supposed to be the amount of required users from the tick to the next scheduled one.

For this last statement I would ask @willr3 and @rvansa if they got historical memories why the `Math.max` was required.