### PR TITLE
Uses JCTools primary lock-free queue on Session pooling

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,6 +66,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
         </dependency>

--- a/core/src/main/java/io/hyperfoil/core/impl/ElasticPoolImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/ElasticPoolImpl.java
@@ -1,12 +1,15 @@
 package io.hyperfoil.core.impl;
 
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Supplier;
 
 import io.hyperfoil.api.collection.ElasticPool;
+import io.netty.util.internal.PlatformDependent;
+import org.jctools.queues.MpmcArrayQueue;
+import org.jctools.queues.MpmcUnboundedXaddArrayQueue;
+import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
 
 public class ElasticPoolImpl<T> implements ElasticPool<T> {
    protected final LongAdder used = new LongAdder();
@@ -14,8 +17,10 @@ public class ElasticPoolImpl<T> implements ElasticPool<T> {
    private final Supplier<T> depletionSupplier;
    protected volatile int minUsed;
    protected volatile int maxUsed;
-   private ArrayBlockingQueue<T> primaryQueue;
-   private final BlockingQueue<T> secondaryQueue = new LinkedBlockingQueue<>();
+   private Queue<T> primaryQueue;
+   private final Queue<T> secondaryQueue = PlatformDependent.hasUnsafe() ?
+           new MpmcUnboundedXaddArrayQueue<>(128) :
+           new ConcurrentLinkedQueue<>();
 
    public ElasticPoolImpl(Supplier<T> initSupplier, Supplier<T> depletionSupplier) {
       this.initSupplier = initSupplier;
@@ -52,17 +57,39 @@ public class ElasticPoolImpl<T> implements ElasticPool<T> {
       secondaryQueue.add(object);
    }
 
-   @Override
-   public void reserve(int capacity) {
-      if (primaryQueue == null || primaryQueue.size() < capacity) {
-         primaryQueue = new ArrayBlockingQueue<>(capacity);
-      }
-      while (primaryQueue.size() < capacity) {
-         primaryQueue.add(initSupplier.get());
-      }
-   }
+    @Override
+    public void reserve(int capacity) {
+        if (primaryQueue == null) {
+            final int qCapacity = Math.max(2, capacity);
+            primaryQueue = PlatformDependent.hasUnsafe() ?
+                    new MpmcArrayQueue<>(qCapacity) :
+                    new MpmcAtomicArrayQueue<>(qCapacity);
+            for (int i = 0; i < capacity; i++) {
+                primaryQueue.offer(initSupplier.get());
+            }
+            assert primaryQueue.size() == capacity;
+            return;
+        }
+        final int currentCapacity = primaryQueue.size();
+        if (currentCapacity >= capacity) {
+            return;
+        }
+        var oldStorage = primaryQueue;
+        primaryQueue = null;
+        final int qCapacity = Math.max(2, capacity);
+        primaryQueue = PlatformDependent.hasUnsafe() ?
+                new MpmcArrayQueue<>(qCapacity) :
+                new MpmcAtomicArrayQueue<>(qCapacity);
+        for (int i = 0; i < currentCapacity; i++) {
+            primaryQueue.offer(oldStorage.poll());
+        }
+        for (int i = currentCapacity; i < capacity; i++) {
+            primaryQueue.offer(initSupplier.get());
+        }
+        assert primaryQueue.size() == capacity;
+    }
 
-   public void incrementUsed() {
+    public void incrementUsed() {
       used.increment();
       long currentlyUsed = used.longValue();
       if (currentlyUsed > maxUsed) {
@@ -83,14 +110,17 @@ public class ElasticPoolImpl<T> implements ElasticPool<T> {
       assert currentlyUsed >= 0;
    }
 
+   @Override
    public int minUsed() {
       return minUsed;
    }
 
+   @Override
    public int maxUsed() {
       return maxUsed;
    }
 
+   @Override
    public void resetStats() {
       int current = used.intValue();
       minUsed = current;

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <version.jboss-threads>3.5.0.Final</version.jboss-threads>
         <version.jboss-logging>3.5.0.Final</version.jboss-logging>
         <version.wildfly-common>1.6.0.Final</version.wildfly-common>
+        <version.jctools>4.0.5</version.jctools>
 
         <version.sonatype.nexus>1.6.13</version.sonatype.nexus>
         <version.maven.source>3.2.1</version.maven.source>
@@ -435,6 +436,12 @@
                 <groupId>org.wildfly.common</groupId>
                 <artifactId>wildfly-common</artifactId>
                 <version>${version.wildfly-common}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jctools</groupId>
+                <artifactId>jctools-core</artifactId>
+                <version>${version.jctools}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fixes #359 

## Changes proposed
- [x] Use a lock-free mpmc queue for the primary queue's elastic pool used for Session pooling
- [ ] JCTools mpmc unbounded xadd queue comes with a footprint cost: evaluate if is better to just use CLQ   
- [ ]  Introduce a shiny new JMH module where we can put new benchmarks, including something to validate the previous point 
- [x] Improve `reserve` to recycle the already pooled sessions while expanding (it affect `wrk2`) 
- [ ]  write a test which reproduce the above the problem
- [ ] evaluate if the pool should be elastic or not, given that AFAIK we cannot create sessions on demand and we use it just for sessions 