### PR TITLE
[cli/stats] Add max response time

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/Stats.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Stats.java
@@ -34,7 +34,7 @@ public class Stats extends BaseRunIdCommand {
          .columnNanos("p90", r -> r.summary.percentileResponseTime.get(90d))
          .columnNanos("p99", r -> r.summary.percentileResponseTime.get(99d))
          .columnNanos("p99.9", r -> r.summary.percentileResponseTime.get(99.9))
-         .columnNanos("p99.99", r -> r.summary.percentileResponseTime.get(99.99))
+         .columnNanos("MAX", r -> r.summary.maxResponseTime)
          .columnInt("TIMEOUTS", r -> r.summary.requestTimeouts)
          .columnInt("ERRORS", r -> r.summary.connectionErrors + r.summary.internalErrors)
          .columnNanos("BLOCKED", r -> r.summary.blockedTime);

--- a/cli/src/main/java/io/hyperfoil/cli/commands/Stats.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Stats.java
@@ -30,11 +30,12 @@ public class Stats extends BaseRunIdCommand {
          .columnInt("REQUESTS", r -> r.summary.requestCount)
          .columnNanos("MEAN", r -> r.summary.meanResponseTime)
          .columnNanos("STD_DEV", r -> r.summary.stdDevResponseTime)
+         .columnNanos("MAX", r -> r.summary.maxResponseTime)
          .columnNanos("p50", r -> r.summary.percentileResponseTime.get(50d))
          .columnNanos("p90", r -> r.summary.percentileResponseTime.get(90d))
          .columnNanos("p99", r -> r.summary.percentileResponseTime.get(99d))
          .columnNanos("p99.9", r -> r.summary.percentileResponseTime.get(99.9))
-         .columnNanos("MAX", r -> r.summary.maxResponseTime)
+         .columnNanos("p99.99", r -> r.summary.percentileResponseTime.get(99.99))
          .columnInt("TIMEOUTS", r -> r.summary.requestTimeouts)
          .columnInt("ERRORS", r -> r.summary.connectionErrors + r.summary.internalErrors)
          .columnNanos("BLOCKED", r -> r.summary.blockedTime);


### PR DESCRIPTION
Max response time is one of the most important response time values to keep an eye on, and the stats display already had enough percentile response time values.

````
[hyperfoil@in-vm]$ stats
Total stats from run 0004
PHASE    METRIC  THROUGHPUT   REQUESTS  MEAN      STD_DEV  p50       p90       p99       p99.9     MAX       TIMEOUTS  ERRORS  BLOCKED  2xx  3xx  4xx  5xx  CACHE
example  test    29,41 req/s         1  17,37 ms     0 ns  17,43 ms  17,43 ms  17,43 ms  17,43 ms  17,43 ms         0       0     0 ns    0    1    0    0      0
[hyperfoil@in-vm]$ 
````