### PR TITLE
Add simulation initialization time log

### DIFF
--- a/api/src/main/java/io/hyperfoil/internal/Properties.java
+++ b/api/src/main/java/io/hyperfoil/internal/Properties.java
@@ -37,6 +37,7 @@ public interface Properties {
    String RUN_ID = "io.hyperfoil.runid";
    String TRIGGER_URL = "io.hyperfoil.trigger.url";
    String CLI_REQUEST_TIMEOUT = "io.hyperfoil.cli.request.timeout";
+   String GC_CHECK = "io.hyperfoil.gc.check.enabled";
 
    static String get(String property, String def) {
       return get(property, Function.identity(), def);

--- a/core/src/main/java/io/hyperfoil/core/impl/OpenModelPhase.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/OpenModelPhase.java
@@ -75,7 +75,7 @@ final class OpenModelPhase extends PhaseInstanceImpl implements FireTimeListener
         // given that both computeNextFireTime and onFireTimes can take some time, we need to adjust the fire time
         long scheduledFireDelayMs = Math.max(0, (expectedNextFireTimeMs - elapsedTimeMs) - rateGenerationDelayMs);
         if (trace) {
-            log.trace("{}: {} after start, {} started ({} throttled), next user in {} ms, scheduling decisions tooks {} ms", def.name, elapsedTimeMs,
+            log.trace("{}: {} after start, {} started ({} throttled), next user in {} ms, scheduling decisions took {} ms", def.name, elapsedTimeMs,
                     rateGenerator.fireTimes(), throttledUsers, scheduledFireDelayMs, rateGenerationDelayMs);
         }
         if (scheduledFireDelayMs <= 0) {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Hyperfoil/issues/371

## Changes proposed

Add simple time log identifying the time spent by the simulation initialization, which includes the sessions allocation and `GC` manual invocation.

As part of this monitoring enhancement, the following changes
have been added:
- Overall simulation init execution time
- GC execution time
- Run GC twice with forced finalization
- Additional check to ensure GC properly worked (configurable)

The additional check is disabled by default but it can be
switched on by providing -Dio.hyperfoil.gc.check.enabled=true

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>