### PR TITLE
Rate generators session pool workstealing

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/session/PhaseInstance.java
+++ b/api/src/main/java/io/hyperfoil/api/session/PhaseInstance.java
@@ -28,6 +28,8 @@ public interface PhaseInstance {
    // TODO better name
    void setComponents(ElasticPool<Session> sessionPool, List<Session> sessionList, PhaseChangeHandler phaseChangeHandler);
 
+   void runOnFailedSessionAcquisition(Runnable action);
+
    void reserveSessions();
 
    void notifyFinished(Session session);
@@ -35,8 +37,6 @@ public interface PhaseInstance {
    void setTerminated();
 
    void fail(Throwable error);
-
-   void setSessionLimitExceeded();
 
    Throwable getError();
 

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.hyperfoil</groupId>
+        <artifactId>hyperfoil-all</artifactId>
+        <version>0.27-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>benchmarks</artifactId>
+    <name>Hyperfoil Benchmarks</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.37</jmh.version>
+    </properties>
+
+    <!-- use jmh -->
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.hyperfoil</groupId>
+            <artifactId>hyperfoil-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/benchmarks/src/main/java/io/hyperfoil/core/counters/CountersScalability.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/counters/CountersScalability.java
@@ -1,0 +1,189 @@
+package io.hyperfoil.core.counters;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+@State(Scope.Benchmark)
+@Fork(value = 2)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class CountersScalability {
+
+
+    @State(Scope.Thread)
+    public static class ThreadLocalCounter {
+
+        private static final AtomicIntegerFieldUpdater<ThreadLocalCounter> COUNTER_UPDATER = AtomicIntegerFieldUpdater.newUpdater(ThreadLocalCounter.class, "counter");
+        private volatile int counter;
+        private int counterId;
+
+        @Setup
+        public void setup(CountersScalability countersScalability) {
+            counterId = countersScalability.registerThreadState(this);
+        }
+
+        public int weakIncrementAndGet() {
+            int nextValue = counter + 1;
+            COUNTER_UPDATER.lazySet(this, nextValue);
+            return nextValue;
+        }
+
+        public int atomicIncrementAndGet() {
+            return COUNTER_UPDATER.incrementAndGet(this);
+        }
+
+        public int getCounter() {
+            return counter;
+        }
+
+        public int atomicDecrementAndGet() {
+            return COUNTER_UPDATER.decrementAndGet(this);
+        }
+
+        public int weakDecrementAndGet() {
+            int nextValue = counter - 1;
+            COUNTER_UPDATER.lazySet(this, nextValue);
+            return nextValue;
+        }
+    }
+
+    private static final AtomicIntegerFieldUpdater<CountersScalability> MIN_UPDATER = AtomicIntegerFieldUpdater.newUpdater(CountersScalability.class, "min");
+    private static final AtomicIntegerFieldUpdater<CountersScalability> MAX_UPDATER = AtomicIntegerFieldUpdater.newUpdater(CountersScalability.class, "max");
+    private static final AtomicIntegerFieldUpdater<CountersScalability> SHARED_COUNTER_UPDATER = AtomicIntegerFieldUpdater.newUpdater(CountersScalability.class, "sharedCounter");
+
+    private AtomicInteger nextCounter;
+    private ThreadLocalCounter[] counters;
+    private int threads;
+    private volatile int min;
+    private volatile int max;
+    private volatile int sharedCounter;
+
+    @Setup
+    public void setup(BenchmarkParams params) {
+        threads = params.getThreads();
+        nextCounter = new AtomicInteger();
+        counters = new ThreadLocalCounter[threads];
+    }
+
+    private int registerThreadState(ThreadLocalCounter threadLocalCounter) {
+        int counterId = nextCounter.getAndIncrement();
+        counters[counterId] = threadLocalCounter;
+        return counterId;
+    }
+
+    private int atomicIncrement(ThreadLocalCounter counter) {
+        var counters = this.counters;
+        int indexToSkip = counter.counterId;
+        int threads = this.threads;
+        int usage = counter.atomicIncrementAndGet();
+        for (int i = 0; i < threads; i++) {
+            if (i != indexToSkip) {
+                usage += counters[i].getCounter();
+            }
+        }
+        if (usage > max) {
+            MAX_UPDATER.lazySet(this, usage);
+        }
+        return usage;
+    }
+
+    private int atomicDecrement(ThreadLocalCounter counter) {
+        var counters = this.counters;
+        int indexToSkip = counter.counterId;
+        int threads = this.threads;
+        int usage = counter.atomicDecrementAndGet();
+        for (int i = 0; i < threads; i++) {
+            if (i != indexToSkip) {
+                usage += counters[i].getCounter();
+            }
+        }
+        if (usage < min) {
+            MIN_UPDATER.lazySet(this, usage);
+        }
+        return usage;
+    }
+
+    private int weakIncrement(ThreadLocalCounter counter) {
+        var counters = this.counters;
+        int indexToSkip = counter.counterId;
+        int threads = this.threads;
+        int usage = counter.weakIncrementAndGet();
+        for (int i = 0; i < threads; i++) {
+            if (i != indexToSkip) {
+                usage += counters[i].getCounter();
+            }
+        }
+        if (usage > max) {
+            MAX_UPDATER.lazySet(this, usage);
+        }
+        return usage;
+    }
+
+    private int weakDecrement(ThreadLocalCounter counter) {
+        var counters = this.counters;
+        int indexToSkip = counter.counterId;
+        int threads = this.threads;
+        int usage = counter.weakDecrementAndGet();
+        for (int i = 0; i < threads; i++) {
+            if (i != indexToSkip) {
+                usage += counters[i].getCounter();
+            }
+        }
+        if (usage < min) {
+            MIN_UPDATER.lazySet(this, usage);
+        }
+        return usage;
+    }
+
+
+    @Benchmark
+    public int atomicUsage(ThreadLocalCounter counter) {
+        int up = atomicIncrement(counter);
+        int down = atomicDecrement(counter);
+        return up + down;
+    }
+
+    @Benchmark
+    public int weakUsage(ThreadLocalCounter counter) {
+        int up = weakIncrement(counter);
+        int down = weakDecrement(counter);
+        return up + down;
+    }
+
+    @Benchmark
+    public int sharedUsage() {
+        int up = sharedIncrement();
+        int down = sharedDecrement();
+        return up + down;
+    }
+
+    private int sharedDecrement() {
+        int value = SHARED_COUNTER_UPDATER.decrementAndGet(this);
+        int min = this.min;
+        if (min > 0 && value < min) {
+            MIN_UPDATER.lazySet(this, value);
+        }
+        return value;
+    }
+
+    private int sharedIncrement() {
+        int value = SHARED_COUNTER_UPDATER.incrementAndGet(this);
+        if (value > max) {
+            MAX_UPDATER.lazySet(this, value);
+        }
+        return value;
+    }
+
+}

--- a/benchmarks/src/main/java/io/hyperfoil/core/harness/EventLoopGroupHarnessExecutor.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/harness/EventLoopGroupHarnessExecutor.java
@@ -1,0 +1,14 @@
+package io.hyperfoil.core.harness;
+
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+public class EventLoopGroupHarnessExecutor extends DefaultEventExecutorGroup {
+
+    public static final CopyOnWriteArraySet<EventLoopGroupHarnessExecutor> TOTAL_EVENT_EXECUTORS = new CopyOnWriteArraySet<>();
+
+    public EventLoopGroupHarnessExecutor(int nThreads, String ignored) {
+        super(nThreads);
+        TOTAL_EVENT_EXECUTORS.add(this);
+    }
+}

--- a/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeEventExecutor.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeEventExecutor.java
@@ -1,0 +1,53 @@
+package io.hyperfoil.core.impl;
+
+import io.netty.util.concurrent.AbstractEventExecutor;
+import io.netty.util.concurrent.Future;
+
+import java.util.concurrent.TimeUnit;
+
+public class FakeEventExecutor extends AbstractEventExecutor {
+    @Override
+    public boolean isShuttingDown() {
+        return false;
+    }
+
+    @Override
+    public Future<?> shutdownGracefully(long quietPeriod, long timeout, TimeUnit unit) {
+        return null;
+    }
+
+    @Override
+    public Future<?> terminationFuture() {
+        return null;
+    }
+
+    @Override
+    public void shutdown() {
+
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return false;
+    }
+
+    @Override
+    public boolean inEventLoop(Thread thread) {
+        return false;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+
+    }
+}

--- a/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
@@ -1,0 +1,198 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.config.Phase;
+import io.hyperfoil.api.config.Scenario;
+import io.hyperfoil.api.connection.Request;
+import io.hyperfoil.api.session.AgentData;
+import io.hyperfoil.api.session.GlobalData;
+import io.hyperfoil.api.session.PhaseInstance;
+import io.hyperfoil.api.session.SequenceInstance;
+import io.hyperfoil.api.session.Session;
+import io.hyperfoil.api.session.ThreadData;
+import io.hyperfoil.api.statistics.SessionStatistics;
+import io.hyperfoil.api.statistics.Statistics;
+import io.netty.util.concurrent.EventExecutor;
+
+import java.util.function.Supplier;
+
+public class FakeSession implements Session {
+
+    private final EventExecutor executor;
+    private final int agentThreadId;
+
+    public FakeSession(EventExecutor executor, int agentThreadId) {
+        this.executor = executor;
+        this.agentThreadId = agentThreadId;
+    }
+
+
+    @Override
+    public Runnable runTask() {
+        return null;
+    }
+
+    @Override
+    public void reserve(Scenario scenario) {
+
+    }
+
+    @Override
+    public int uniqueId() {
+        return 0;
+    }
+
+    @Override
+    public int agentThreadId() {
+        return agentThreadId;
+    }
+
+    @Override
+    public int agentThreads() {
+        return 0;
+    }
+
+    @Override
+    public int globalThreadId() {
+        return 0;
+    }
+
+    @Override
+    public int globalThreads() {
+        return 0;
+    }
+
+    @Override
+    public int agentId() {
+        return 0;
+    }
+
+    @Override
+    public int agents() {
+        return 0;
+    }
+
+    @Override
+    public String runId() {
+        return "";
+    }
+
+    @Override
+    public EventExecutor executor() {
+        return executor;
+    }
+
+    @Override
+    public ThreadData threadData() {
+        return null;
+    }
+
+    @Override
+    public AgentData agentData() {
+        return null;
+    }
+
+    @Override
+    public GlobalData globalData() {
+        return null;
+    }
+
+    @Override
+    public PhaseInstance phase() {
+        return null;
+    }
+
+    @Override
+    public long phaseStartTimestamp() {
+        return 0;
+    }
+
+    @Override
+    public Statistics statistics(int stepId, String name) {
+        return null;
+    }
+
+    @Override
+    public void pruneStats(Phase phase) {
+
+    }
+
+    @Override
+    public <R extends Resource> void declareResource(ResourceKey<R> key, Supplier<R> resourceSupplier) {
+
+    }
+
+    @Override
+    public <R extends Resource> void declareResource(ResourceKey<R> key, Supplier<R> resourceSupplier, boolean singleton) {
+
+    }
+
+    @Override
+    public <R extends Resource> void declareSingletonResource(ResourceKey<R> key, R resource) {
+
+    }
+
+    @Override
+    public <R extends Resource> R getResource(ResourceKey<R> key) {
+        return null;
+    }
+
+    @Override
+    public void currentSequence(SequenceInstance current) {
+
+    }
+
+    @Override
+    public SequenceInstance currentSequence() {
+        return null;
+    }
+
+    @Override
+    public void attach(EventExecutor executor, ThreadData threadData, AgentData agentData, GlobalData globalData, SessionStatistics statistics) {
+
+    }
+
+    @Override
+    public void start(PhaseInstance phase) {
+
+    }
+
+    @Override
+    public void proceed() {
+
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public SequenceInstance startSequence(String name, boolean forceSameIndex, ConcurrencyPolicy policy) {
+        return null;
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public void fail(Throwable t) {
+
+    }
+
+    @Override
+    public boolean isActive() {
+        return false;
+    }
+
+    @Override
+    public Request currentRequest() {
+        return null;
+    }
+
+    @Override
+    public void currentRequest(Request request) {
+
+    }
+}

--- a/benchmarks/src/main/java/io/hyperfoil/core/impl/PoolBenchmark.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/impl/PoolBenchmark.java
@@ -1,0 +1,121 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.collection.ElasticPool;
+import io.hyperfoil.api.session.Session;
+import io.hyperfoil.core.harness.EventLoopGroupHarnessExecutor;
+import io.netty.util.concurrent.EventExecutor;
+import org.openjdk.jmh.annotations.AuxCounters;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = {"-Djmh.executor=CUSTOM", "-Djmh.executor.class=io.hyperfoil.core.harness.EventLoopGroupHarnessExecutor"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class PoolBenchmark {
+
+    @Param({"0"})
+    private int work;
+    @Param({"1024"})
+    private int capacity;
+    @Param({"1"})
+    private int burst;
+    @Param({"true"})
+    private boolean workStealingPool;
+    @Param({ "0", "16" })
+    private int fakeEventExecutors;
+
+    private ElasticPool<Session> pool;
+
+    @Setup
+    public void setup(BenchmarkParams params) {
+        if (EventLoopGroupHarnessExecutor.TOTAL_EVENT_EXECUTORS.size() != 1) {
+            throw new IllegalStateException("Expected exactly one EventLoopExecutor");
+        }
+        var executorGroup = EventLoopGroupHarnessExecutor.TOTAL_EVENT_EXECUTORS.iterator().next();
+        var executors = StreamSupport.stream(executorGroup.spliterator(), false)
+                .map(EventExecutor.class::cast).toArray(EventExecutor[]::new);
+        if (executors.length != params.getThreads()) {
+            throw new IllegalStateException("Expected " + params.getThreads() + " executors, got " + executors.length);
+        }
+        executors = Arrays.copyOf(executors, executors.length + fakeEventExecutors);
+        // create some fake EventExecutors here, if needed
+        for (int i = executors.length - fakeEventExecutors; i < executors.length; i++) {
+            executors[i] = new FakeEventExecutor();
+        }
+        // sessions are distributed among the perceived event executors, in round-robin
+        var sessions = createSessions(executors, capacity);
+        if (!workStealingPool) {
+            pool = new LockBasedElasticPool<>(sessions::poll, () -> {
+                System.exit(1);
+                return null;
+            });
+        } else {
+            pool = new AffinityAwareSessionPool(executors, sessions::poll);
+        }
+        pool.reserve(capacity);
+    }
+
+    protected static Queue<Session> createSessions(EventExecutor[] executors, int sessions) {
+        var queue = new ArrayDeque<Session>(sessions);
+        for (int i = 0; i < sessions; i++) {
+            int agentThreadId = i % executors.length;
+            final var eventExecutor = executors[agentThreadId];
+            final Session session = new FakeSession(eventExecutor, agentThreadId);
+            queue.add(session);
+        }
+        return queue;
+    }
+
+
+    @AuxCounters
+    @State(Scope.Thread)
+    public static class Counters {
+        public long acquired;
+        public long released;
+        private ArrayDeque<Session> pooledAcquired;
+
+        @Setup
+        public void setup(PoolBenchmark benchmark) {
+            pooledAcquired = new ArrayDeque<>(benchmark.burst);
+        }
+    }
+
+    @Benchmark
+    public int acquireAndRelease(Counters counters) {
+        var pool = this.pool;
+        int acquired = 0;
+        var pooledAcquired = counters.pooledAcquired;
+        for (int i = 0; i < burst; ++i) {
+            var pooledObject = pool.acquire();
+            pooledAcquired.add(pooledObject);
+        }
+        counters.acquired += burst;
+        int work = this.work;
+        if (work > 0) {
+            Blackhole.consumeCPU(work);
+        }
+        for (int i = 0; i < burst; ++i) {
+            pool.release(pooledAcquired.poll());
+        }
+        counters.released += burst;
+        return acquired;
+    }
+
+}

--- a/benchmarks/src/main/java/io/hyperfoil/core/impl/PoolReserveBenchmark.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/impl/PoolReserveBenchmark.java
@@ -1,0 +1,78 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.collection.ElasticPool;
+import io.hyperfoil.api.session.Session;
+import io.netty.util.concurrent.EventExecutor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import java.util.ArrayDeque;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Fork(value = 2)
+@BenchmarkMode(Mode.SingleShotTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class PoolReserveBenchmark {
+
+    @Param({"128", "1024", "131072"})
+    private int capacity;
+
+    @Param({"0", "1", "2", "4"})
+    private int eventExecutors;
+
+    private ElasticPool<Session> pool;
+
+    @Setup
+    public void setup() {
+        var eventExecutors = new EventExecutor[this.eventExecutors];
+        for (int i = 0; i < eventExecutors.length; i++) {
+            eventExecutors[i] = new FakeEventExecutor();
+        }
+        var sessions = new ArrayDeque<Session>(capacity);
+        long executorSequence = 0;
+        for (int i = 0; i < capacity; i++) {
+            Session session;
+            if (eventExecutors.length > 0) {
+                int agentThreadId = (int) (executorSequence++ % eventExecutors.length);
+                session = new FakeSession(eventExecutors[agentThreadId], agentThreadId);
+            } else {
+                session = new FakeSession(null, 0);
+            }
+            sessions.add(session);
+        }
+        // this is just to have some class loading done, really
+        // but need to be careful to not trigger too much JIT!
+        var sessionsCopy = new ArrayDeque<>(sessions);
+        if (eventExecutors.length > 0) {
+            pool = new AffinityAwareSessionPool(eventExecutors, sessionsCopy::poll);
+        } else {
+            pool = new LockBasedElasticPool<>(sessionsCopy::poll, () -> {
+                System.exit(1);
+                return null;
+            });
+        }
+        if (eventExecutors.length > 0) {
+            pool.reserve(eventExecutors.length);
+            pool = new AffinityAwareSessionPool(eventExecutors, sessions::poll);
+        } else {
+            pool.reserve(1);
+            pool = new LockBasedElasticPool<>(sessions::poll, () -> {
+                System.exit(1);
+                return null;
+            });
+        }
+    }
+
+    @Benchmark
+    public void reserve() {
+        pool.reserve(capacity);
+    }
+
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,6 +66,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
         </dependency>
@@ -135,7 +140,12 @@
             <version>3.6.1</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/io/hyperfoil/core/impl/AffinityAwareSessionPool.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/AffinityAwareSessionPool.java
@@ -1,0 +1,258 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.collection.ElasticPool;
+import io.hyperfoil.api.session.Session;
+import io.netty.util.concurrent.EventExecutor;
+import io.netty.util.concurrent.FastThreadLocal;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.ThreadExecutorMap;
+import org.jctools.queues.MpmcArrayQueue;
+import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
+
+import java.util.IdentityHashMap;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.function.Supplier;
+
+/**
+ * This class represents a pool of sessions that are aware of thread affinity.
+ * It implements the {@link ElasticPool} interface and provides methods to acquire and release sessions.<br>
+ * The pool maintains a separate queue of sessions for each event executor (thread),
+ * and tries to acquire and release sessions from the queue of the current executor.
+ * If the local queue is empty, it tries to steal sessions from other queues.
+ */
+public class AffinityAwareSessionPool implements ElasticPool<Session> {
+
+    private final FastThreadLocal<Integer> localAgentThreadId;
+    private final IdentityHashMap<EventExecutor, Integer> agentThreadIdPerExecutor;
+    private final Queue<Session>[] localQueues;
+    private final Supplier<Session> sessionSupplier;
+
+    /**
+     * We're using a single array to store multiple counters, mostly to avoid false sharing with other fields
+     * in this same class (which are mostly read-only).<br>
+     * We still pad used/min/max from each others to avoid max and min to interfere with each other.
+     * There's no point to use a LongAdder here, because reading the counters would hit worse than sharing a single one
+     * which can leverage fast x86 fetch-and-add instructions.
+     */
+    private static final int PADDING_INTS = 128 / Integer.BYTES; // 32
+    private static final int USED_OFFSET = PADDING_INTS; // 32
+    private static final int MIN_USED_OFFSET = USED_OFFSET + PADDING_INTS; // 32 + 32 = 64
+    private static final int MAX_USED_OFFSET = MIN_USED_OFFSET + PADDING_INTS; // 64 + 32 = 96
+    private static final int COUNTERS_INTS = MAX_USED_OFFSET + PADDING_INTS; // 96 + 32 = 128
+    private final AtomicIntegerArray counters;
+
+    public AffinityAwareSessionPool(EventExecutor[] eventExecutors, Supplier<Session> sessionSupplier) {
+        this.sessionSupplier = sessionSupplier;
+        this.agentThreadIdPerExecutor = new IdentityHashMap<>(eventExecutors.length);
+        this.localQueues = new Queue[eventExecutors.length];
+        for (int agentThreadId = 0; agentThreadId < eventExecutors.length; agentThreadId++) {
+            agentThreadIdPerExecutor.put(eventExecutors[agentThreadId], agentThreadId);
+        }
+        this.localAgentThreadId = new FastThreadLocal<>() {
+            @Override
+            protected Integer initialValue() {
+                var eventExecutor = ThreadExecutorMap.currentExecutor();
+                return eventExecutor == null ? null : agentThreadIdPerExecutor.get(eventExecutor);
+            }
+        };
+        this.counters = new AtomicIntegerArray(COUNTERS_INTS);
+    }
+
+    private int nextWorkStealIndex() {
+        return ThreadLocalRandom.current().nextInt(0, localQueues.length);
+    }
+
+    private int nextWorkStealIndex(int excludeIndex) {
+        var localQueuesCount = localQueues.length;
+        var workStealIndex = localQueuesCount == 2 ? excludeIndex : ThreadLocalRandom.current().nextInt(0, localQueuesCount);
+        if (workStealIndex == excludeIndex) {
+            workStealIndex++;
+            if (workStealIndex == localQueuesCount) {
+                workStealIndex = 0;
+            }
+        }
+        return workStealIndex;
+    }
+
+
+    @Override
+    public Session acquire() {
+        var boxedAgentThreadId = localAgentThreadId.get();
+        if (boxedAgentThreadId == null) {
+            return acquireFromLocalQueues();
+        }
+        // explicitly unbox to save unboxing it again, in case work-stealing happens
+        var agentThreadId = boxedAgentThreadId.intValue();
+        var localQueues = this.localQueues;
+        var session = localQueues[agentThreadId].poll();
+        if (session != null) {
+            incrementUsed();
+            return session;
+        }
+        if (localQueues.length == 1) {
+            return null;
+        }
+        return acquireFromOtherLocalQueues(localQueues, agentThreadId);
+    }
+
+    private Session acquireFromLocalQueues() {
+        int currentIndex = nextWorkStealIndex();
+        var localQueues = this.localQueues;
+        int localQueuesCount = localQueues.length;
+        for (Queue<Session> localQueue : localQueues) {
+            Session session = localQueue.poll();
+            if (session != null) {
+                incrementUsed();
+                return session;
+            }
+            currentIndex++;
+            if (currentIndex == localQueuesCount) {
+                currentIndex = 0;
+            }
+        }
+        return null;
+    }
+
+    private Session acquireFromOtherLocalQueues(Queue<Session>[] localQueues, int agentThreadIdToSkip) {
+        int currentIndex = nextWorkStealIndex(agentThreadIdToSkip);
+        var localQueuesCount = localQueues.length;
+        // this loop start from the workStealIndex, but while iterating can still end up
+        // at the index we want to ignore, so we need to skip it
+        for (int i = 0; i < localQueuesCount; i++) {
+            if (currentIndex != agentThreadIdToSkip) {
+                var localQ = localQueues[currentIndex];
+                if (localQ != null) {
+                    var session = localQ.poll();
+                    if (session != null) {
+                        incrementUsed();
+                        return session;
+                    }
+                }
+            }
+            currentIndex++;
+            if (currentIndex == localQueuesCount) {
+                currentIndex = 0;
+            }
+        }
+        return null;
+    }
+
+    private void incrementUsed() {
+        var counters = this.counters;
+        int used = counters.incrementAndGet(USED_OFFSET);
+        int maxUsed = counters.get(MAX_USED_OFFSET);
+        if (used > maxUsed) {
+            counters.lazySet(MAX_USED_OFFSET, used);
+        }
+    }
+
+    private void decrementUsed() {
+        var counters = this.counters;
+        int used = counters.decrementAndGet(USED_OFFSET);
+        int minUsed = counters.get(MIN_USED_OFFSET);
+        if (minUsed > 0 && used < minUsed) {
+            counters.lazySet(MIN_USED_OFFSET, used);
+        }
+    }
+
+    @Override
+    public void release(Session session) {
+        Objects.requireNonNull(session);
+        var localQueue = localQueues[session.agentThreadId()];
+        decrementUsed();
+        localQueue.add(session);
+    }
+
+    @Override
+    public void reserve(int capacity) {
+        int totalCapacity = getLocalQueuesCapacity();
+        if (totalCapacity >= capacity) {
+            return;
+        }
+        moveNewSessionsToLocalQueues(capacity, totalCapacity);
+    }
+
+    private int getLocalQueuesCapacity() {
+        int totalCapacity = 0;
+        for (Queue<Session> localQueue : localQueues) {
+            if (localQueue != null) {
+                totalCapacity += localQueue.size();
+            }
+        }
+        return totalCapacity;
+    }
+
+    private void moveNewSessionsToLocalQueues(int requiredCapacity, int currentCapacity) {
+        final int newCapacity = requiredCapacity - currentCapacity;
+        // assume fair distribution of new sessions
+        var perEventExecutorNewCapacity = (int) Math.ceil((double) newCapacity / localQueues.length);
+        var sessionSupplier = this.sessionSupplier;
+        var localQueues = this.localQueues;
+        var agentThreadIdPerExecutor = this.agentThreadIdPerExecutor;
+        // It keeps track of the local queues capacity not yet reserved
+        boolean[] localQueueReservedCapacity = new boolean[localQueues.length];
+        for (int i = 0; i < newCapacity; i++) {
+            var newSession = sessionSupplier.get();
+            var eventExecutor = newSession.executor();
+            var boxedAgentThreadId = agentThreadIdPerExecutor.get(eventExecutor);
+            if (boxedAgentThreadId == null) {
+                throw new IllegalStateException("No agentThreadId for executor " + eventExecutor);
+            }
+            var agentThreadId = boxedAgentThreadId.intValue();
+            var localQueue = localQueues[agentThreadId];
+            if (!localQueueReservedCapacity[agentThreadId]) {
+                localQueueReservedCapacity[agentThreadId] = true;
+                if (localQueue == null) {
+                    localQueue = createLocalQueue(perEventExecutorNewCapacity);
+                    localQueues[agentThreadId] = localQueue;
+                } else {
+                    var newLocalQueue = createLocalQueue(localQueue.size() + perEventExecutorNewCapacity);
+                    newLocalQueue.addAll(localQueue);
+                    localQueue.clear();
+                    localQueue = newLocalQueue;
+                    localQueues[agentThreadId] = newLocalQueue;
+                }
+            }
+            if (!localQueue.offer(newSession)) {
+                throw new IllegalStateException("Failed to add new session to local queue: sessions are not fairly distributed");
+            }
+        }
+        for (int i = 0; i < localQueueReservedCapacity.length; i++) {
+            if (!localQueueReservedCapacity[i]) {
+                var localQ = localQueues[i];
+                if (localQ == null) {
+                    localQ = createLocalQueue(0);
+                    this.localQueues[i] = localQ;
+                }
+            }
+        }
+    }
+
+    private Queue<Session> createLocalQueue(int capacity) {
+        if (PlatformDependent.hasUnsafe()) {
+            return new MpmcArrayQueue<>(Math.max(2, capacity));
+        }
+        return new MpmcAtomicArrayQueue<>(Math.max(2, capacity));
+    }
+
+    @Override
+    public int minUsed() {
+        return counters.get(MIN_USED_OFFSET);
+    }
+
+    @Override
+    public int maxUsed() {
+        return counters.get(MAX_USED_OFFSET);
+    }
+
+    @Override
+    public void resetStats() {
+        var counters = this.counters;
+        int used = counters.get(USED_OFFSET);
+        counters.lazySet(MAX_USED_OFFSET, used);
+        counters.lazySet(MIN_USED_OFFSET, used);
+    }
+}

--- a/core/src/main/java/io/hyperfoil/core/impl/OpenModelPhase.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/OpenModelPhase.java
@@ -54,7 +54,6 @@ final class OpenModelPhase extends PhaseInstanceImpl implements FireTimeListener
         if (remainingMsToFirstFireTime > 0) {
             executorGroup.schedule(() -> proceed(executorGroup), remainingMsToFirstFireTime, TimeUnit.MILLISECONDS);
         } else {
-            // we are not enforcing to be called from an event loop thread here, and indeed tests uses the main thread:
             proceed(executorGroup);
         }
     }

--- a/core/src/test/java/io/hyperfoil/core/impl/ElasticPoolTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/ElasticPoolTest.java
@@ -1,0 +1,90 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.collection.ElasticPool;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public abstract class ElasticPoolTest<T> extends PoolTest<T> {
+
+    protected abstract ElasticPool<T> createPoolWith(Supplier<T> initSupplier, Supplier<T> depletionSupplier);
+
+    @Override
+    protected ElasticPool<T> createPoolWith(final Supplier<T> initSupplier) {
+        return createPoolWith(initSupplier, () -> {
+            Assert.fail("Depleted supplier should not be called");
+            return null;
+        });
+    }
+
+    @Test
+    public void acquireReleseBeyondReservedCapacity() {
+        final int reservedCapacity = 10;
+        final var reservedItemsCounter = new AtomicInteger();
+        final var depletedItemsCounter = new AtomicInteger();
+        final var pool = createPoolWith(() -> {
+            reservedItemsCounter.incrementAndGet();
+            return createNewItem();
+        }, () -> {
+            depletedItemsCounter.incrementAndGet();
+            return createNewItem();
+        });
+        assertEquals(0, reservedItemsCounter.get());
+        assertEquals(0, depletedItemsCounter.get());
+        pool.reserve(reservedCapacity);
+
+        final var acquiredItems = new HashSet<T>(reservedCapacity);
+        for (int i = 0; i < reservedCapacity; i++) {
+            final var acquired = pool.acquire();
+            assertNotNull(acquired);
+            assertTrue(acquiredItems.add(acquired));
+            assertEquals(reservedCapacity, reservedItemsCounter.get());
+            assertEquals(0, depletedItemsCounter.get());
+            assertEquals(i + 1, pool.maxUsed());
+            assertEquals(0, pool.minUsed());
+        }
+        final int depletedCapacity = 10;
+        final var depletedItems = new HashSet<T>(depletedCapacity);
+        for (int i = 0; i < depletedCapacity; i++) {
+            final T depleted = pool.acquire();
+            assertNotNull(depleted);
+            assertFalse(acquiredItems.contains(depleted));
+            assertTrue(depletedItems.add(depleted));
+            assertEquals(reservedCapacity, reservedItemsCounter.get());
+            assertEquals(i + 1, depletedItemsCounter.get());
+            assertEquals(reservedCapacity + (i + 1), pool.maxUsed());
+            assertEquals(0, pool.minUsed());
+        }
+        assertEquals(depletedCapacity, depletedItems.size());
+        // release the depleted items
+        for (final T depleted : depletedItems) {
+            pool.release(depleted);
+            assertEquals(reservedCapacity, reservedItemsCounter.get());
+            assertEquals(depletedCapacity, depletedItemsCounter.get());
+            assertEquals(reservedCapacity + depletedCapacity, pool.maxUsed());
+            assertEquals(0, pool.minUsed());
+        }
+        // acquiring it again should just use the depleted items
+        final var depletedItemsReacquired = new HashSet<T>(depletedCapacity);
+        for (int i = 0; i < depletedCapacity; i++) {
+            final var depleted = pool.acquire();
+            assertNotNull(depleted);
+            assertFalse(acquiredItems.contains(depleted));
+            assertTrue(depletedItemsReacquired.add(depleted));
+            assertEquals(reservedCapacity, reservedItemsCounter.get());
+            assertEquals(depletedCapacity, depletedItemsCounter.get());
+            assertEquals(reservedCapacity + depletedCapacity, pool.maxUsed());
+            assertEquals(0, pool.minUsed());
+        }
+        // verify that the reacquired items are the same
+        assertEquals(depletedItems, depletedItemsReacquired);
+    }
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/EventExecutorSessionPoolTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/EventExecutorSessionPoolTest.java
@@ -1,0 +1,123 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.collection.ElasticPool;
+import io.hyperfoil.api.session.Session;
+import io.hyperfoil.core.test.CustomExecutorRunner;
+import io.netty.channel.DefaultEventLoop;
+import io.netty.util.concurrent.DefaultEventExecutorGroup;
+import io.netty.util.concurrent.EventExecutor;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(CustomExecutorRunner.class)
+public class EventExecutorSessionPoolTest extends PoolTest<Session> {
+
+    private static EventExecutor[] executors;
+    private int nextEventExecutor = 0;
+
+    @BeforeClass
+    public static void configureRunnerExecutor() {
+        final var eventExecutors = new DefaultEventExecutorGroup(11);
+        executors = StreamSupport.stream(eventExecutors.spliterator(), false)
+                .map(EventExecutor.class::cast).toArray(EventExecutor[]::new);
+        CustomExecutorRunner.TEST_EVENT_EXECUTOR = eventExecutors;
+    }
+
+    @Override
+    protected ElasticPool<Session> createPoolWith(final Supplier<Session> initSupplier) {
+        return new AffinityAwareSessionPool(executors, initSupplier);
+    }
+
+    @Override
+    protected Session createNewItem() {
+        final Session session = mock(Session.class);
+        final var eventExecutor = executors[nextEventExecutor];
+        when(session.executor()).thenReturn(eventExecutor);
+        when(session.agentThreadId()).thenReturn(nextEventExecutor);
+        nextEventExecutor++;
+        if (nextEventExecutor >= executors.length) {
+            nextEventExecutor = 0;
+        }
+        return session;
+    }
+
+    @Test
+    public void reserveBeyondReservedCapacityReuseAndExtendTheCapacity() {
+        final int reservedCapacity = 10;
+        final var reservedItemsCounter = new AtomicInteger();
+        final var pool = createPoolWith(() -> {
+            reservedItemsCounter.incrementAndGet();
+            return createNewItem();
+        });
+        assertEquals(0, reservedItemsCounter.get());
+        pool.reserve(reservedCapacity);
+        final var reservedItems = new HashSet<Session>(reservedCapacity);
+        for (int i = 0; i < reservedCapacity; i++) {
+            final var acquired = pool.acquire();
+            assertTrue(reservedItems.add(acquired));
+            assertNotNull(acquired);
+        }
+        // release all reserved items
+        for (final Session acquired : reservedItems) {
+            pool.release(acquired);
+        }
+        assertEquals(reservedCapacity, reservedItemsCounter.get());
+        final int additionalCapacity = 10;
+        pool.reserve(reservedCapacity + additionalCapacity);
+        assertEquals(reservedCapacity + additionalCapacity, reservedItemsCounter.get());
+        final var newReservedItems = new HashSet<Session>(reservedCapacity + additionalCapacity);
+        for (int i = 0; i < reservedCapacity + additionalCapacity; i++) {
+            final var acquired = pool.acquire();
+            assertNotNull(acquired);
+            assertTrue(newReservedItems.add(acquired));
+        }
+        assertTrue(newReservedItems.containsAll(reservedItems));
+        assertNull(pool.acquire());
+    }
+
+    @Test
+    public void acquireReleaseWithinReservedCapacityFromAlienThread() {
+        var error = new CompletableFuture<>();
+        Thread alienThread = new Thread(() -> {
+            try {
+                super.acquireReleaseWithinReservedCapacity();
+                error.complete(null);
+            } catch (Throwable t) {
+                error.completeExceptionally(t);
+            }
+        });
+        alienThread.start();
+        Assert.assertNull(error.join());
+    }
+
+    @Test
+    public void acquireReleaseWithinReservedCapacityFromAlienEventExecutor() {
+        var eventLoop = new DefaultEventLoop();
+        try {
+            var testResult = eventLoop.submit(super::acquireReleaseWithinReservedCapacity);
+            // capture the exception if any
+            try {
+                testResult.get();
+            } catch (Throwable e) {
+                Assert.fail(e.getMessage());
+            }
+        } finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/LockBasedElasticPoolTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/LockBasedElasticPoolTest.java
@@ -1,0 +1,20 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.collection.ElasticPool;
+
+import java.util.function.Supplier;
+
+
+public class LockBasedElasticPoolTest extends ElasticPoolTest<Object> {
+
+    @Override
+    protected ElasticPool<Object> createPoolWith(final Supplier<Object> initSupplier, final Supplier<Object> depletionSupplier) {
+        return new LockBasedElasticPool<>(initSupplier, depletionSupplier);
+    }
+
+    @Override
+    protected Object createNewItem() {
+        return new Object();
+    }
+
+}

--- a/core/src/test/java/io/hyperfoil/core/impl/PoolTest.java
+++ b/core/src/test/java/io/hyperfoil/core/impl/PoolTest.java
@@ -1,0 +1,130 @@
+package io.hyperfoil.core.impl;
+
+import io.hyperfoil.api.collection.ElasticPool;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public abstract class PoolTest<T> {
+
+    protected abstract ElasticPool<T> createPoolWith(Supplier<T> initSupplier);
+
+    /**
+     * The pooled items factory must create a whole new instance each time, to work
+     */
+    protected abstract T createNewItem();
+
+    @Test
+    public void acquireReleaseWithinReservedCapacity() {
+        final int reservedCapacity = 10;
+        final var reservedItemsCounter = new AtomicInteger();
+        final var pool = createPoolWith(() -> {
+            reservedItemsCounter.incrementAndGet();
+            return createNewItem();
+        });
+        assertEquals(0, reservedItemsCounter.get());
+        pool.reserve(reservedCapacity);
+
+        final var reservedItems = new HashSet<T>(reservedCapacity);
+        for (int i = 0; i < reservedCapacity; i++) {
+            final var acquired = pool.acquire();
+            assertNotNull(acquired);
+            assertTrue(reservedItems.add(acquired));
+            assertEquals(reservedCapacity, reservedItemsCounter.get());
+            assertEquals(i + 1, pool.maxUsed());
+            assertEquals(0, pool.minUsed());
+        }
+        assertEquals(reservedCapacity, reservedItems.size());
+        for (final T acquired : reservedItems) {
+            pool.release(acquired);
+            assertEquals(reservedCapacity, reservedItemsCounter.get());
+            assertEquals(reservedCapacity, pool.maxUsed());
+            assertEquals(0, pool.minUsed());
+        }
+        final var reservedItemsReacquired = new HashSet<T>(reservedCapacity);
+        for (int i = 0; i < reservedCapacity; i++) {
+            final var acquired = pool.acquire();
+            assertNotNull(acquired);
+            assertTrue(reservedItemsReacquired.add(acquired));
+            assertEquals(reservedCapacity, reservedItemsCounter.get());
+            assertEquals(reservedCapacity, pool.maxUsed());
+            assertEquals(0, pool.minUsed());
+        }
+        assertEquals(reservedItems, reservedItemsReacquired);
+    }
+
+    @Test(expected = Exception.class)
+    public void cannotAcquireAcquireWithoutReservingFirst() {
+        final var pool = createPoolWith(() -> {
+            Assert.fail("Init supplier should not be called");
+            return null;
+        });
+        pool.acquire();
+    }
+
+    @Test(expected = Exception.class)
+    public void cannotReleaseWithoutReservingFirst() {
+        final var pool = createPoolWith(() -> {
+            Assert.fail("Init supplier should not be called");
+            return null;
+        });
+        pool.release(createNewItem());
+    }
+
+    @Test(expected = Exception.class)
+    public void cannotReleaseANullItem() {
+        final var pool = createPoolWith(this::createNewItem);
+        pool.reserve(1);
+        // ignore what's acquired
+        assertNotNull(pool.acquire());
+        pool.release(null);
+    }
+
+    @Test
+    public void reserveBelowExistingReservedCapacityShouldReuseWholeCapacity() {
+        final int reservedCapacity = 10;
+        final var reservedItemsCounter = new AtomicInteger();
+        final var pool = createPoolWith(() -> {
+            reservedItemsCounter.incrementAndGet();
+            return createNewItem();
+        });
+        assertEquals(0, reservedItemsCounter.get());
+        pool.reserve(reservedCapacity);
+        assertEquals(reservedCapacity, reservedItemsCounter.get());
+        pool.reserve(0);
+        for (int i = 0; i < reservedCapacity; i++) {
+            assertNotNull(pool.acquire());
+        }
+    }
+
+    @Test
+    public void statsShouldReflectPoolUsage() {
+        final int reservedCapacity = 10;
+        final var pool = createPoolWith(this::createNewItem);
+        pool.reserve(reservedCapacity);
+        var reservedItems = new ArrayDeque<T>(reservedCapacity);
+        for (int i = 0; i < reservedCapacity; i++) {
+            reservedItems.add(pool.acquire());
+            assertEquals(0, pool.minUsed());
+            assertEquals(i + 1, pool.maxUsed());
+        }
+        pool.resetStats();
+        assertEquals(reservedCapacity, pool.maxUsed());
+        assertEquals(reservedCapacity, pool.minUsed());
+        for (int i = 0; i < reservedCapacity; i++) {
+            var toRelease = reservedItems.poll();
+            pool.release(toRelease);
+            assertEquals(reservedCapacity - (i + 1), pool.minUsed());
+            assertEquals(reservedCapacity, pool.maxUsed());
+        }
+    }
+
+}

--- a/core/src/test/java/io/hyperfoil/core/test/CustomExecutorRunner.java
+++ b/core/src/test/java/io/hyperfoil/core/test/CustomExecutorRunner.java
@@ -1,0 +1,51 @@
+package io.hyperfoil.core.test;
+
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public class CustomExecutorRunner extends BlockJUnit4ClassRunner {
+
+    public static ExecutorService TEST_EVENT_EXECUTOR;
+
+    public CustomExecutorRunner(Class<?> klass) throws InitializationError {
+        super(klass);
+    }
+
+    @Override
+    protected Statement methodBlock(final FrameworkMethod method) {
+        Objects.requireNonNull(TEST_EVENT_EXECUTOR, "Executor is not set");
+        final Statement statement = super.methodBlock(method);
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Future<?> future = TEST_EVENT_EXECUTOR.submit(() -> {
+                    try {
+                        statement.evaluate();
+                    } catch (Throwable throwable) {
+                        throw new RuntimeException(throwable);
+                    }
+                });
+                future.get(); // wait for the test to complete
+            }
+        };
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        try {
+            super.run(notifier);
+        } finally {
+            var executor = TEST_EVENT_EXECUTOR;
+            if (executor != null) {
+                executor.shutdown();
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>plugins/maven</module>
         <module>test-suite</module>
         <module>hotrod</module>
+        <module>benchmarks</module>
     </modules>
 
     <!-- Licenses -->
@@ -96,6 +97,7 @@
         <version.jboss-threads>3.5.0.Final</version.jboss-threads>
         <version.jboss-logging>3.5.0.Final</version.jboss-logging>
         <version.wildfly-common>1.6.0.Final</version.wildfly-common>
+        <version.jctools>4.0.5</version.jctools>
 
         <version.sonatype.nexus>1.6.13</version.sonatype.nexus>
         <version.maven.source>3.3.0</version.maven.source>
@@ -435,6 +437,12 @@
                 <groupId>org.wildfly.common</groupId>
                 <artifactId>wildfly-common</artifactId>
                 <version>${version.wildfly-common}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jctools</groupId>
+                <artifactId>jctools-core</artifactId>
+                <version>${version.jctools}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fixes #359 

## Changes proposed

- [x] Implemented basic striped pool implementation
- [X] Adding unit tests
- [X] Adding JMH benchmark module
- [x] Leverage Thread-affinity of `Session`s to populate and assign it to dedicated queues

The last point is crucial to better work with the phase instance which acquire `Session`s: instead of relying on a random thread affinity (assigned in round robin) - we should just use the initial provided one (thinking about the `Session`s specific use case here) in order to both reduce contention and guarantee the thread-local acquired `Session` is executed in the same `Thread` who requested it.
The implication of this choice are not obvious because it means that in a multithreading scenario where the phase instance acquire the Session, it will start it delayed after it complete the `proceed` call, which is something to be evaluated if is the right choice.