### PR TITLE
Make HTTP cache configurable

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/WrkAbstract.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/WrkAbstract.java
@@ -155,6 +155,9 @@ public abstract class WrkAbstract {
       @Option(name = "enable-http2", description = "HTTP2 is not supported in wrk/wrk2: you can enable that for Hyperfoil.", defaultValue = "false")
       boolean enableHttp2;
 
+      @Option(name = "use-http-cache", description = "By default the HTTP cache is disabled, providing this option you can enable it.", hasValue = false)
+      boolean useHttpCache;
+
       @Argument(description = "URL that should be accessed", required = true)
       String url;
 
@@ -220,6 +223,7 @@ public abstract class WrkAbstract {
                      .protocol(protocol).host(uri.getHost()).port(protocol.portOrDefault(uri.getPort()))
                      .allowHttp2(enableHttp2)
                      .sharedConnections(connections)
+                     .useHttpCache(useHttpCache)
                   .endHttp()
                .endPlugin()
                .threads(this.threads);

--- a/http/src/main/java/io/hyperfoil/http/HttpRequestPool.java
+++ b/http/src/main/java/io/hyperfoil/http/HttpRequestPool.java
@@ -14,8 +14,8 @@ public class HttpRequestPool extends LimitedPoolResource<HttpRequest> {
    private static final boolean trace = log.isTraceEnabled();
    public static final Session.ResourceKey<LimitedPoolResource<HttpRequest>> KEY = new Key<>();
 
-   public HttpRequestPool(Scenario scenario, Session session) {
-      super(scenario.maxRequests(), HttpRequest.class, () -> new HttpRequest(session));
+   public HttpRequestPool(Scenario scenario, Session session, boolean httpCacheEnabled) {
+      super(scenario.maxRequests(), HttpRequest.class, () -> new HttpRequest(session, httpCacheEnabled));
    }
 
    public static LimitedPool<HttpRequest> get(Session session) {

--- a/http/src/main/java/io/hyperfoil/http/config/Http.java
+++ b/http/src/main/java/io/hyperfoil/http/config/Http.java
@@ -46,11 +46,13 @@ public class Http implements Serializable {
    private final KeyManager keyManager;
    private final TrustManager trustManager;
    private final ConnectionStrategy connectionStrategy;
+   private final boolean useHttpCache;
 
-   public Http(String name, boolean isDefault, String originalDestination, Protocol protocol, String host, int port, String[] addresses,
-               HttpVersion[] versions, int maxHttp2Streams, int pipeliningLimit, ConnectionPoolConfig sharedConnections,
-               boolean directHttp2, long requestTimeout, boolean rawBytesHandlers,
-               KeyManager keyManager, TrustManager trustManager, ConnectionStrategy connectionStrategy) {
+   public Http(String name, boolean isDefault, String originalDestination, Protocol protocol, String host, int port,
+               String[] addresses, HttpVersion[] versions, int maxHttp2Streams, int pipeliningLimit,
+               ConnectionPoolConfig sharedConnections, boolean directHttp2, long requestTimeout,
+               boolean rawBytesHandlers, KeyManager keyManager, TrustManager trustManager,
+               ConnectionStrategy connectionStrategy, boolean useHttpCache) {
       this.name = name;
       this.isDefault = isDefault;
       this.originalDestination = originalDestination;
@@ -68,6 +70,7 @@ public class Http implements Serializable {
       this.keyManager = keyManager;
       this.trustManager = trustManager;
       this.connectionStrategy = connectionStrategy;
+      this.useHttpCache = useHttpCache;
    }
 
    public String name() {
@@ -141,6 +144,10 @@ public class Http implements Serializable {
 
    public ConnectionStrategy connectionStrategy() {
       return connectionStrategy;
+   }
+
+   public boolean enableHttpCache() {
+      return useHttpCache;
    }
 
    public static class KeyManager implements Serializable {

--- a/http/src/main/java/io/hyperfoil/http/config/HttpBuilder.java
+++ b/http/src/main/java/io/hyperfoil/http/config/HttpBuilder.java
@@ -58,6 +58,7 @@ public class HttpBuilder implements BuilderBase<HttpBuilder> {
    private KeyManagerBuilder keyManager = new KeyManagerBuilder(this);
    private TrustManagerBuilder trustManager = new TrustManagerBuilder(this);
    private ConnectionStrategy connectionStrategy = ConnectionStrategy.SHARED_POOL;
+   private boolean useHttpCache = true;
 
    public static HttpBuilder forTesting() {
       return new HttpBuilder(null);
@@ -233,6 +234,15 @@ public class HttpBuilder implements BuilderBase<HttpBuilder> {
       return connectionStrategy;
    }
 
+   public HttpBuilder useHttpCache(boolean useHttpCache) {
+      this.useHttpCache = useHttpCache;
+      return this;
+   }
+
+   public boolean useHttpCache() {
+      return useHttpCache;
+   }
+
    public void prepareBuild() {
    }
 
@@ -262,10 +272,10 @@ public class HttpBuilder implements BuilderBase<HttpBuilder> {
          }
       }
       Protocol protocol = this.protocol != null ? this.protocol : Protocol.fromPort(port);
-      return http = new Http(name, isDefault, originalDestination, protocol, host, protocol.portOrDefault(port), addresses.toArray(new String[0]),
-            httpVersions.toArray(new HttpVersion[0]), maxHttp2Streams, pipeliningLimit,
-            sharedConnections.build(), directHttp2, requestTimeout, rawBytesHandlers, keyManager.build(), trustManager.build(),
-            connectionStrategy);
+      return http = new Http(name, isDefault, originalDestination, protocol, host, protocol.portOrDefault(port),
+            addresses.toArray(new String[0]), httpVersions.toArray(new HttpVersion[0]), maxHttp2Streams,
+            pipeliningLimit, sharedConnections.build(), directHttp2, requestTimeout, rawBytesHandlers,
+            keyManager.build(), trustManager.build(), connectionStrategy, useHttpCache);
    }
 
    public static class KeyManagerBuilder implements BuilderBase<KeyManagerBuilder> {

--- a/http/src/main/java/io/hyperfoil/http/parser/HttpParser.java
+++ b/http/src/main/java/io/hyperfoil/http/parser/HttpParser.java
@@ -35,6 +35,7 @@ public class HttpParser extends AbstractParser<BenchmarkBuilder, HttpBuilder> {
       register("keyManager", new ReflectionParser<>(HttpBuilder::keyManager));
       register("trustManager", new ReflectionParser<>(HttpBuilder::trustManager));
       register("connectionStrategy", new PropertyParser.Enum<>(ConnectionStrategy.values(), HttpBuilder::connectionStrategy));
+      register("useHttpCache", new PropertyParser.Boolean<>(HttpBuilder::useHttpCache));
    }
 
    @Override

--- a/http/src/main/java/io/hyperfoil/http/steps/ClearHttpCacheAction.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/ClearHttpCacheAction.java
@@ -10,7 +10,10 @@ import io.hyperfoil.http.api.HttpCache;
 public class ClearHttpCacheAction implements Action {
    @Override
    public void run(Session session) {
-      HttpCache.get(session).clear();
+      HttpCache httpCache = HttpCache.get(session);
+      if (httpCache != null) {
+         httpCache.clear();
+      }
    }
 
    /**

--- a/http/src/test/java/io/hyperfoil/http/cache/HttpCacheEnablementTest.java
+++ b/http/src/test/java/io/hyperfoil/http/cache/HttpCacheEnablementTest.java
@@ -1,0 +1,85 @@
+package io.hyperfoil.http.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.hyperfoil.core.impl.LocalSimulationRunner;
+import io.hyperfoil.http.HttpScenarioTest;
+import io.hyperfoil.http.api.HttpCache;
+import io.hyperfoil.http.api.HttpMethod;
+import io.hyperfoil.http.config.HttpBuilder;
+import io.hyperfoil.http.config.HttpPluginBuilder;
+import io.hyperfoil.http.steps.HttpStepCatalog;
+import io.vertx.core.Future;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+
+public class HttpCacheEnablementTest extends HttpScenarioTest {
+
+   @Override
+   protected Future<Void> startServer(TestContext ctx, boolean tls, boolean compression) {
+      // don't start the server
+      return null;
+   }
+
+   private void startServer(TestContext ctx) {
+      Async async = ctx.async();
+      super.startServer(ctx, false, false).onComplete(ctx.asyncAssertSuccess(nil -> async.complete()));
+      async.await();
+   }
+
+   @Override
+   protected void initRouter() {
+      router.route("/ok").handler(ctx -> vertx.setTimer(5, id -> ctx.response().end()));
+      router.route("/error").handler(ctx -> vertx.setTimer(5, id -> ctx.response().setStatusCode(400).end()));
+      router.route("/close").handler(ctx -> ctx.response().reset());
+   }
+
+   @Test
+   public void testOkWithoutCacheHttp1x(TestContext ctx) {
+      startServer(ctx);
+      http().useHttpCache(false)
+            .sharedConnections(1);
+      testSingle("/ok", false);
+   }
+
+   @Test
+   public void testOkWithCacheHttp1x(TestContext ctx) {
+      startServer(ctx);
+      http().useHttpCache(true)
+            .sharedConnections(1);
+      testSingle("/ok", true);
+   }
+
+   @Test
+   public void testOkWithCacheByDefaultHttp1x(TestContext ctx) {
+      startServer(ctx);
+      http().sharedConnections(1);
+      testSingle("/ok", true);
+   }
+
+   private void testSingle(String path, boolean isUsingCache) {
+      AtomicReference<HttpCache> httpCacheRef = new AtomicReference<>();
+      benchmarkBuilder.addPhase("test").atOnce(1).duration(10).scenario()
+            .initialSequence("test")
+            .step(session -> {
+               httpCacheRef.set(HttpCache.get(session));
+               return true;
+            })
+            .step(HttpStepCatalog.SC).httpRequest(HttpMethod.GET).path(path).endStep();
+
+      TestStatistics requestStats = new TestStatistics();
+      LocalSimulationRunner runner = new LocalSimulationRunner(benchmarkBuilder.build(), requestStats,
+            null, null);
+      runner.run();
+
+      assertThat(httpCacheRef.get() != null).isEqualTo(isUsingCache);
+   }
+
+   private HttpBuilder http() {
+      return benchmarkBuilder.plugin(HttpPluginBuilder.class).http();
+   }
+}

--- a/http/src/test/java/io/hyperfoil/http/cookie/CookieStoreTest.java
+++ b/http/src/test/java/io/hyperfoil/http/cookie/CookieStoreTest.java
@@ -168,7 +168,7 @@ public class CookieStoreTest {
 
       @Override
       public HttpRequest request() {
-         HttpRequest httpRequest = new HttpRequest(null);
+         HttpRequest httpRequest = new HttpRequest(null, true);
          httpRequest.path = path;
          return httpRequest;
       }

--- a/http/src/test/java/io/hyperfoil/http/handlers/FilterHeaderHandlerTest.java
+++ b/http/src/test/java/io/hyperfoil/http/handlers/FilterHeaderHandlerTest.java
@@ -89,7 +89,7 @@ public class FilterHeaderHandlerTest {
    }
 
    private HttpRequest requestMock(WriteAccess... accesses) {
-      HttpRequest request = new HttpRequest(SessionFactory.forTesting(accesses));
+      HttpRequest request = new HttpRequest(SessionFactory.forTesting(accesses), true);
       request.attach(new BaseMockConnection() {
          @Override
          public ChannelHandlerContext context() {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Note that this is based on https://github.com/Hyperfoil/Hyperfoil/pull/372, therefore this might be merged only once the other one is merged and this one properly rebased.
 
## Fixes Issue

Fixes https://github.com/Hyperfoil/Hyperfoil/issues/361

## Changes proposed

Made the HTTP cache configurable as there might be use cases, and then benchmarks, that do not require any HTTP cache.

By default the HTTP cache is enabled, mainly for backward compatibility reasons but it can be disabled by adding `useHttpCache: false` in the `http` definition:
```yaml
name: first-benchmark
http:
  host: http://localhost:8080
  sharedConnections: 10
  useHttpCache: false
```
> [!NOTE]
> If there are multiple `http` authorities, you need to disable the cache on all of them to really disable it.

Disabling the HTTP cache (if not really required) will heavily reduce the amount allocated java object (and therefore the used heap) during the benchmark simulation initialization.

TODOs:
- [ ] Planning to provide some before/after comparisons in the comments.
- [x] Update the documentation including the new `useHttpCache` option (edit: https://github.com/Hyperfoil/hyperfoil.github.io/pull/60).


## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>