### PR TITLE
Reduce maxRequests to 1 for Wrk HTTP 1.1

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/WrkAbstract.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/WrkAbstract.java
@@ -330,6 +330,8 @@ public abstract class WrkAbstract {
          if (!enableHttp2) {
             // given that we don't support pipelining we can just safely limit the maxRequests to 1
             scenarioBuilder.maxRequests(1);
+            // each session can have only one sequence
+            scenarioBuilder.maxSequences(1);
          }
          return scenarioBuilder
                   .initialSequence("request")

--- a/cli/src/main/java/io/hyperfoil/cli/commands/WrkAbstract.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/WrkAbstract.java
@@ -323,10 +323,15 @@ public abstract class WrkAbstract {
          String[][] parsedHeaders = this.parsedHeaders;
          long duration = Util.parseToMillis(durationStr);
          // @formatter:off
-         return phaseConfig(benchmarkBuilder.addPhase(phase))
+         var scenarioBuilder = phaseConfig(benchmarkBuilder.addPhase(phase))
                  .duration(duration)
                  .maxDuration(duration + Util.parseToMillis(timeout))
-                 .scenario()
+                 .scenario();
+         if (!enableHttp2) {
+            // given that we don't support pipelining we can just safely limit the maxRequests to 1
+            scenarioBuilder.maxRequests(1);
+         }
+         return scenarioBuilder
                   .initialSequence("request")
                      .step(SC).httpRequest(HttpMethod.GET)
                         .path(path)


### PR DESCRIPTION
## Fixes Issue #380 

## Changes proposed

This is just better configuring `maxRequests` while waiting to better implement `HttpRequestPool` to 
fix it by automatically estimate it - making the `maxRequests` configuration option obsolete.