### PR TITLE
Fixes #385 Optimize 0 and 1 Sequence's concurrency on HTTP

### DIFF
--- a/core/src/main/java/io/hyperfoil/core/util/BitSetResource.java
+++ b/core/src/main/java/io/hyperfoil/core/util/BitSetResource.java
@@ -1,11 +1,86 @@
 package io.hyperfoil.core.util;
 
-import java.util.BitSet;
-
 import io.hyperfoil.api.session.Session;
 
-public class BitSetResource extends BitSet implements Session.Resource {
-   public BitSetResource(int nbits) {
-      super(nbits);
+import java.util.BitSet;
+
+public interface BitSetResource extends Session.Resource {
+
+   void set(int index);
+
+   boolean get(int index);
+
+   void clear(int index);
+
+   static BitSetResource with(int nbits) {
+      if (nbits == 0 || nbits == 1) {
+         class SingleBitSetResource implements BitSetResource {
+
+            private boolean set;
+
+            @Override
+            public void set(int index) {
+               validateBitIndex(index);
+               set = true;
+            }
+
+            private static void validateBitIndex(int index) {
+               if (index != 0) {
+                  throw new IndexOutOfBoundsException();
+               }
+            }
+
+            @Override
+            public boolean get(int index) {
+               validateBitIndex(index);
+               return set;
+            }
+
+            @Override
+            public void clear(int index) {
+               validateBitIndex(index);
+               set = false;
+            }
+         }
+
+         return new SingleBitSetResource();
+      }
+      class MultiBitSetResource extends BitSet implements BitSetResource {
+
+         private final int nBits;
+
+         MultiBitSetResource(int nbits) {
+            super(nbits);
+            this.nBits = nbits;
+         }
+
+         @Override
+         public void set(final int bitIndex) {
+            validateBitIndex(bitIndex);
+            super.set(bitIndex);
+         }
+
+         private void validateBitIndex(int bitIndex) {
+            if (bitIndex >= nBits) {
+               throw new IndexOutOfBoundsException();
+            }
+         }
+
+         @Override
+         public boolean get(final int bitIndex) {
+            validateBitIndex(bitIndex);
+            return super.get(bitIndex);
+         }
+
+         @Override
+         public void clear(final int bitIndex) {
+            validateBitIndex(bitIndex);
+            super.clear(bitIndex);
+         }
+      }
+
+      return new MultiBitSetResource(nbits);
    }
+
+
 }

--- a/http/src/main/java/io/hyperfoil/http/steps/BeforeSyncRequestStep.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/BeforeSyncRequestStep.java
@@ -16,6 +16,6 @@ class BeforeSyncRequestStep implements Step, ResourceUtilizer, Session.ResourceK
    @Override
    public void reserve(Session session) {
       int concurrency = session.currentSequence().definition().concurrency();
-      session.declareResource(this, () -> new BitSetResource(concurrency), true);
+      session.declareResource(this, () -> BitSetResource.with(concurrency), true);
    }
 }

--- a/http/src/test/java/io/hyperfoil/http/steps/HttpConcurrentRequestTest.java
+++ b/http/src/test/java/io/hyperfoil/http/steps/HttpConcurrentRequestTest.java
@@ -1,0 +1,90 @@
+package io.hyperfoil.http.steps;
+
+import io.hyperfoil.api.statistics.StatisticsSnapshot;
+import io.hyperfoil.core.handlers.NewSequenceAction;
+import io.hyperfoil.http.HttpScenarioTest;
+import io.hyperfoil.http.api.HttpMethod;
+import io.hyperfoil.http.config.HttpPluginBuilder;
+import io.hyperfoil.http.handlers.RangeStatusValidator;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.handler.BodyHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+import static io.hyperfoil.http.steps.HttpStepCatalog.SC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(VertxUnitRunner.class)
+public class HttpConcurrentRequestTest extends HttpScenarioTest {
+
+    private ArrayList<Integer> responsesReceived = new ArrayList<>();
+
+    @Override
+    protected void initRouter() {
+        router.route().handler(BodyHandler.create());
+        router.get("/test").handler(ctx -> {
+            responsesReceived.add(Integer.parseInt(ctx.request().getParam("concurrency")));
+            ctx.response().setStatusCode(200).end();
+        });
+    }
+
+       @Test
+   public void testConcurrencyZeroWithPipelining() {
+      testConcurrencyWithPipelining(0);
+   }
+
+    @Test
+    public void testConcurrencyOneWithPipelining() {
+      testConcurrencyWithPipelining(1);
+    }
+
+    @Test
+    public void testConcurrencyManyWithPipelining() {
+      testConcurrencyWithPipelining(16);
+    }
+
+   private void testConcurrencyWithPipelining(int concurrency) {
+      int sequenceInvocation = concurrency == 0 ? 1 : concurrency;
+      int pipeliningLimit = concurrency == 0 ? 1 : concurrency;
+      int requiredSequences = concurrency == 0 ? 2 : 1;
+      int maxRequests = concurrency == 0 ? 1 : concurrency;
+      // @formatter:off
+      scenario()
+              .maxSequences(requiredSequences)
+              .maxRequests(maxRequests)
+              .initialSequence("looper")
+                 .step(SC).loop("counter", sequenceInvocation)
+                 .steps()
+                     .step(SC).action(new NewSequenceAction.Builder().sequence("expectOK"))
+              .endSequence()
+              .sequence("expectOK")
+                  .concurrency(concurrency)
+                  .step(SC).httpRequest(HttpMethod.GET)
+                        .path("/test?concurrency=${counter}")
+                        .handler()
+                           .status(new RangeStatusValidator(200, 200))
+                        .endHandler()
+                     .endStep()
+                  .endSequence()
+        .endScenario()
+     .endPhase()
+              .plugin(HttpPluginBuilder.class)
+                  .http()
+                     .sharedConnections(1)
+                     .pipeliningLimit(pipeliningLimit);
+      // @formatter:on
+      Map<String, StatisticsSnapshot> stats = runScenario();
+      StatisticsSnapshot snapshot = stats.get("expectOK");
+      assertThat(snapshot.invalid).isEqualTo(0);
+      assertThat(snapshot.connectionErrors).isEqualTo(0);
+      assertThat(snapshot.requestCount).isEqualTo(concurrency == 0 ? 1 : concurrency);
+      assertThat(responsesReceived.size()).isEqualTo(concurrency == 0 ? 1 : concurrency);
+      // this seems counter-intuitive, but despite the sequence is invoked multiple times, we expect
+      // the query parameter to be valued just with the last counter value!
+      assertThat(responsesReceived).containsOnly(sequenceInvocation);
+   }
+
+}


### PR DESCRIPTION
## Fixes Issue #385 

- [x] Added tests stressing the optimized code path

Thanks to this change we're shaving another GB out of 4 (i.e. using than ~3 GB) while using `wrk2 -c 100 -r 100000` .

This improvement should hold outside wrk scripts, depending how many sessions are allocated by a benchmark.