### PR TITLE
PoC: bound life-cycle to declare resources

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/config/Scenario.java
+++ b/api/src/main/java/io/hyperfoil/api/config/Scenario.java
@@ -34,6 +34,7 @@ import io.hyperfoil.api.session.Session;
 import io.hyperfoil.api.session.WriteAccess;
 
 public class Scenario implements Serializable {
+   private static final Session.Var[] EMPTY_VARS = new Session.Var[0];
    private final Sequence[] initialSequences;
    private final Sequence[] sequences;
    private final Map<String, Sequence> sequenceMap;
@@ -103,6 +104,9 @@ public class Scenario implements Serializable {
    }
 
    public Session.Var[] createVars(Session session) {
+      if (uniqueVars == 0) {
+         return EMPTY_VARS;
+      }
       Session.Var[] vars = new Session.Var[uniqueVars];
       for (WriteAccess access : writes) {
          int index = access.index();

--- a/api/src/main/java/io/hyperfoil/api/session/Session.java
+++ b/api/src/main/java/io/hyperfoil/api/session/Session.java
@@ -53,30 +53,44 @@ public interface Session {
 
    // Resources
 
-   /**
-    * See {@link #declareResource(ResourceKey, Supplier, boolean)}, with <code>singleton</code> defaulting to <code>false</code>
-    *
-    * @param key              Unique key (usually the step or handler itself)
-    * @param resourceSupplier Supplier creating the resource, possible multiple times.
-    * @param <R>              Resource type.
-    */
-   <R extends Session.Resource> void declareResource(ResourceKey<R> key, Supplier<R> resourceSupplier);
+   interface ResourceBuilder {
 
-   /**
-    * Reserve space in the session for a resource, stored under given key. If this is executed within
-    * a {@link io.hyperfoil.api.config.Sequence sequence} with non-zero
-    * {@link io.hyperfoil.api.config.Sequence#concurrency() concurrency} the session
-    * stores one resource for each concurrent instance. If this behaviour should be avoided set
-    * <code>singleton</code> to true.
-    *
-    * @param key              Unique key (usually the step or handler itself)
-    * @param resourceSupplier Supplier creating the resource, possible multiple times.
-    * @param singleton        Is the resource shared amongst concurrent sequences?
-    * @param <R>              Resource type.
-    */
-   <R extends Session.Resource> void declareResource(ResourceKey<R> key, Supplier<R> resourceSupplier, boolean singleton);
+      /**
+       * Ensure that the session has capacity for at least <code>capacity</code> resources.
+       *
+       * @param capacity Number of resources.
+       */
+      ResourceBuilder ensureCapacity(int capacity);
 
-   <R extends Session.Resource> void declareSingletonResource(ResourceKey<R> key, R resource);
+      /**
+       * See {@link #add(ResourceKey, Supplier, boolean)}, with <code>singleton</code> defaulting to <code>false</code>
+       *
+       * @param key              Unique key (usually the step or handler itself)
+       * @param resourceSupplier Supplier creating the resource, possible multiple times.
+       * @param <R>              Resource type.
+       */
+      <R extends Session.Resource> ResourceBuilder add(ResourceKey<R> key, Supplier<R> resourceSupplier);
+
+      /**
+       * Reserve space in the session for a resource, stored under given key. If this is executed within
+       * a {@link io.hyperfoil.api.config.Sequence sequence} with non-zero
+       * {@link io.hyperfoil.api.config.Sequence#concurrency() concurrency} the session
+       * stores one resource for each concurrent instance. If this behaviour should be avoided set
+       * <code>singleton</code> to true.
+       *
+       * @param key              Unique key (usually the step or handler itself)
+       * @param resourceSupplier Supplier creating the resource, possible multiple times.
+       * @param singleton        Is the resource shared amongst concurrent sequences?
+       * @param <R>              Resource type.
+       */
+      <R extends Session.Resource> ResourceBuilder add(ResourceKey<R> key, Supplier<R> resourceSupplier, boolean singleton);
+
+      <R extends Session.Resource> ResourceBuilder addSingleton(ResourceKey<R> key, R resource);
+
+      void build();
+   }
+
+   ResourceBuilder declareResources();
 
    <R extends Session.Resource> R getResource(ResourceKey<R> key);
 

--- a/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
@@ -117,18 +117,8 @@ public class FakeSession implements Session {
     }
 
     @Override
-    public <R extends Resource> void declareResource(ResourceKey<R> key, Supplier<R> resourceSupplier) {
-
-    }
-
-    @Override
-    public <R extends Resource> void declareResource(ResourceKey<R> key, Supplier<R> resourceSupplier, boolean singleton) {
-
-    }
-
-    @Override
-    public <R extends Resource> void declareSingletonResource(ResourceKey<R> key, R resource) {
-
+    public ResourceBuilder declareResources() {
+        return null;
     }
 
     @Override

--- a/core/src/main/java/io/hyperfoil/core/handlers/DefragProcessor.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/DefragProcessor.java
@@ -40,7 +40,7 @@ public class DefragProcessor extends Processor.BaseDelegating implements Resourc
       // Note: contrary to the recommended pattern the Context won't reserve all objects ahead, the CompositeByteBuf
       // will be allocated only if needed (and only once). This is necessary since we don't know the type of allocator
       // that is used for the received buffers ahead.
-      session.declareResource(this, Context::new);
+      session.declareResources().add(this, Context::new);
    }
 
    static class Context implements Session.Resource {

--- a/core/src/main/java/io/hyperfoil/core/handlers/DefragTransformer.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/DefragTransformer.java
@@ -36,7 +36,7 @@ public class DefragTransformer extends Transformer.BaseDelegating implements Res
       // Note: contrary to the recommended pattern the Context won't reserve all objects ahead, the CompositeByteBuf
       // will be allocated only if needed (and only once). This is necessary since we don't know the type of allocator
       // that is used for the received buffers ahead.
-      session.declareResource(this, Context::new);
+      session.declareResources().add(this, Context::new);
    }
 
    static class Context implements Session.Resource {

--- a/core/src/main/java/io/hyperfoil/core/handlers/GzipInflatorProcessor.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/GzipInflatorProcessor.java
@@ -61,7 +61,7 @@ public class GzipInflatorProcessor extends MultiProcessor implements ResourceUti
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(this, InflaterResource::new);
+      session.declareResources().add(this, InflaterResource::new);
    }
 
    public class InflaterResource implements Session.Resource {

--- a/core/src/main/java/io/hyperfoil/core/handlers/QueueProcessor.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/QueueProcessor.java
@@ -67,7 +67,7 @@ public class QueueProcessor implements Processor, ResourceUtilizer {
       if (!var.isSet(session)) {
          var.setObject(session, ObjectVar.newArray(session, concurrency));
       }
-      session.declareResource(key, () -> new Queue(var, maxSize, concurrency, sequence, onCompletion), true);
+      session.declareResources().add(key, () -> new Queue(var, maxSize, concurrency, sequence, onCompletion), true);
    }
 
    /**

--- a/core/src/main/java/io/hyperfoil/core/handlers/SearchHandler.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/SearchHandler.java
@@ -98,7 +98,7 @@ public class SearchHandler implements Processor, ResourceUtilizer, Session.Resou
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(this, Context::new);
+      session.declareResources().add(this, Context::new);
    }
 
    class Context extends BaseSearchContext {

--- a/core/src/main/java/io/hyperfoil/core/handlers/SearchValidator.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/SearchValidator.java
@@ -75,7 +75,7 @@ public class SearchValidator implements Processor, ResourceUtilizer, Session.Res
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(this, Context::new);
+      session.declareResources().add(this, Context::new);
    }
 
    static class Context extends BaseSearchContext {

--- a/core/src/main/java/io/hyperfoil/core/handlers/json/JsonHandler.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/json/JsonHandler.java
@@ -54,7 +54,7 @@ public class JsonHandler extends JsonParser implements Processor, ResourceUtiliz
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(this, Context::new);
+      session.declareResources().add(this, Context::new);
    }
 
    @Override

--- a/core/src/main/java/io/hyperfoil/core/handlers/json/JsonUnquotingTransformer.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/json/JsonUnquotingTransformer.java
@@ -153,7 +153,7 @@ public class JsonUnquotingTransformer implements Transformer, Processor, Resourc
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(this, Context::new);
+      session.declareResources().add(this, Context::new);
    }
 
    public static class Context implements Session.Resource {

--- a/core/src/main/java/io/hyperfoil/core/impl/SimulationRunner.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/SimulationRunner.java
@@ -149,8 +149,9 @@ public class SimulationRunner {
             }
          });
          phase.reserveSessions();
-         // at this point all session resources should be reserved
       }
+      // at this point all session resources should be reserved, let's stop the session's resource declaration
+      sessions.forEach(session ->  session.declareResources().build());
       // hint the GC to tenure sessions
       this.runGC();
 

--- a/core/src/main/java/io/hyperfoil/core/steps/DelaySessionStartStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/DelaySessionStartStep.java
@@ -65,7 +65,7 @@ public class DelaySessionStartStep implements Step, ResourceUtilizer {
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(KEY, Holder::new, true);
+      session.declareResources().add(KEY, Holder::new, true);
    }
 
    public static class Holder implements Session.Resource {

--- a/core/src/main/java/io/hyperfoil/core/steps/JsonStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/JsonStep.java
@@ -99,7 +99,7 @@ public class JsonStep implements Step {
 
       @Override
       public void reserve(Session session) {
-         session.declareResource(this, Context::new);
+         session.declareResources().add(this, Context::new);
       }
 
       @Override

--- a/core/src/main/java/io/hyperfoil/core/steps/RestartSequenceAction.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/RestartSequenceAction.java
@@ -23,7 +23,7 @@ public class RestartSequenceAction implements Action, ResourceUtilizer {
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(triggerKey, RestartSequenceStep.Trigger::new);
+      session.declareResources().add(triggerKey, RestartSequenceStep.Trigger::new);
    }
 
    /**

--- a/core/src/main/java/io/hyperfoil/core/steps/SetAction.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/SetAction.java
@@ -161,7 +161,7 @@ public class SetAction implements Action {
 
       @Override
       public void reserve(Session session) {
-         session.declareResource(this, () -> new ValueResource<>(create(session), this::reset));
+         session.declareResources().add(this, () -> new ValueResource<>(create(session), this::reset));
       }
 
       protected abstract T create(Session session);

--- a/core/src/main/java/io/hyperfoil/core/steps/TimestampStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/TimestampStep.java
@@ -50,7 +50,7 @@ public class TimestampStep implements Step, ResourceUtilizer {
    @Override
    public void reserve(Session session) {
       if (formatterKey != null) {
-         session.declareResource(formatterKey, formatterSupplier);
+         session.declareResources().add(formatterKey, formatterSupplier);
       }
    }
 

--- a/core/src/test/java/io/hyperfoil/core/handlers/JsonHandlerTest.java
+++ b/core/src/test/java/io/hyperfoil/core/handlers/JsonHandlerTest.java
@@ -268,7 +268,7 @@ public class JsonHandlerTest {
 
       @Override
       public void reserve(Session session) {
-         session.declareResource(this, Context::new);
+         session.declareResources().add(this, Context::new);
       }
 
       public static class Context implements Session.Resource {

--- a/hotrod/src/main/java/io/hyperfoil/hotrod/HotRodRunData.java
+++ b/hotrod/src/main/java/io/hyperfoil/hotrod/HotRodRunData.java
@@ -48,7 +48,7 @@ public class HotRodRunData implements PluginRunData {
    @Override
    public void initSession(Session session, int executorId, Scenario scenario, Clock clock) {
       HotRodRemoteCachePool pollById = this.pool[executorId];
-      session.declareSingletonResource(HotRodRemoteCachePool.KEY, pollById);
+      session.declareResources().addSingleton(HotRodRemoteCachePool.KEY, pollById);
    }
 
    @Override

--- a/hotrod/src/main/java/io/hyperfoil/hotrod/steps/HotRodRequestStep.java
+++ b/hotrod/src/main/java/io/hyperfoil/hotrod/steps/HotRodRequestStep.java
@@ -88,7 +88,7 @@ public class HotRodRequestStep extends StatisticsStep implements ResourceUtilize
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(futureWrapperKey, HotRodResource::new);
+      session.declareResources().add(futureWrapperKey, HotRodResource::new);
    }
 
    private void trackResponseError(Session session, String metric, Object ex) {

--- a/http/src/main/java/io/hyperfoil/http/HttpRunData.java
+++ b/http/src/main/java/io/hyperfoil/http/HttpRunData.java
@@ -83,11 +83,13 @@ public class HttpRunData implements PluginRunData {
 
    public static void initForTesting(Session session, Clock clock, boolean cacheEnabled) {
       Scenario dummyScenario = new Scenario(new Sequence[0], new Sequence[0], 16, 16);
-      session.declareSingletonResource(HttpDestinationTable.KEY, new HttpDestinationTableImpl(Collections.emptyMap()));
+      var resources = session.declareResources();
+      resources.ensureCapacity(cacheEnabled ? 3 : 2);
+      resources.addSingleton(HttpDestinationTable.KEY, new HttpDestinationTableImpl(Collections.emptyMap()));
       if (cacheEnabled) {
-         session.declareSingletonResource(HttpCache.KEY, new HttpCacheImpl(clock));
+         resources.addSingleton(HttpCache.KEY, new HttpCacheImpl(clock));
       }
-      session.declareSingletonResource(HttpRequestPool.KEY, new HttpRequestPool(dummyScenario, session, cacheEnabled));
+      resources.addSingleton(HttpRequestPool.KEY, new HttpRequestPool(dummyScenario, session, cacheEnabled));
    }
 
    @Override
@@ -109,11 +111,13 @@ public class HttpRunData implements PluginRunData {
                   }
                });
       }
-      session.declareSingletonResource(HttpDestinationTable.KEY, destinations);
+      var resources = session.declareResources();
+      resources.ensureCapacity(hasHttpCacheEnabled ? 3 : 2);
+      resources.addSingleton(HttpDestinationTable.KEY, destinations);
       if (hasHttpCacheEnabled) {
-         session.declareSingletonResource(HttpCache.KEY, new HttpCacheImpl(clock));
+         resources.addSingleton(HttpCache.KEY, new HttpCacheImpl(clock));
       }
-      session.declareSingletonResource(HttpRequestPool.KEY, new HttpRequestPool(scenario, session, hasHttpCacheEnabled));
+      resources.addSingleton(HttpRequestPool.KEY, new HttpRequestPool(scenario, session, hasHttpCacheEnabled));
    }
 
    @Override

--- a/http/src/main/java/io/hyperfoil/http/UserAgentAppender.java
+++ b/http/src/main/java/io/hyperfoil/http/UserAgentAppender.java
@@ -31,7 +31,7 @@ public class UserAgentAppender implements SerializableBiConsumer<Session, HttpRe
    @Override
    public void reserve(Session session) {
       SessionId sessionId = new SessionId(new AsciiString("#" + session.uniqueId() + "@" + HOSTNAME));
-      session.declareResource(this, () -> sessionId);
+      session.declareResources().add(this, () -> sessionId);
    }
 
    public static final class SessionId implements Session.Resource {

--- a/http/src/main/java/io/hyperfoil/http/cookie/CookieRecorder.java
+++ b/http/src/main/java/io/hyperfoil/http/cookie/CookieRecorder.java
@@ -17,8 +17,6 @@ public class CookieRecorder implements HeaderHandler, ResourceUtilizer {
 
    @Override
    public void reserve(Session session) {
-      if (session.getResource(CookieStore.COOKIES) == null) {
-         session.declareResource(CookieStore.COOKIES, CookieStore::new, true);
-      }
+      session.declareResources().add(CookieStore.COOKIES, CookieStore::new, true);
    }
 }

--- a/http/src/main/java/io/hyperfoil/http/handlers/Redirect.java
+++ b/http/src/main/java/io/hyperfoil/http/handlers/Redirect.java
@@ -70,7 +70,7 @@ public class Redirect {
 
       @Override
       public void reserve(Session session) {
-         session.declareResource(poolKey, () -> LimitedPoolResource.create(concurrency, Coords.class, Coords::new), true);
+         session.declareResources().add(poolKey, () -> LimitedPoolResource.create(concurrency, Coords.class, Coords::new), true);
       }
 
       public static class Builder extends BaseDelegatingStatusHandler.Builder<Builder> {
@@ -186,7 +186,7 @@ public class Redirect {
          if (!outputVar.isSet(session)) {
             outputVar.setObject(session, ObjectVar.newArray(session, concurrency));
          }
-         session.declareResource(queueKey, () -> new Queue(outputVar, concurrency, concurrency, sequence, null));
+         session.declareResources().add(queueKey, () -> new Queue(outputVar, concurrency, concurrency, sequence, null));
       }
 
       public static class Builder implements HeaderHandler.Builder {

--- a/http/src/main/java/io/hyperfoil/http/html/FetchResourceHandler.java
+++ b/http/src/main/java/io/hyperfoil/http/html/FetchResourceHandler.java
@@ -72,8 +72,8 @@ public class FetchResourceHandler implements Serializable, ResourceUtilizer {
       if (!var.isSet(session)) {
          var.setObject(session, ObjectVar.newArray(session, concurrency));
       }
-      session.declareResource(queueKey, () -> new Queue(var, maxResources, concurrency, sequence, onCompletion), true);
-      session.declareResource(locationPoolKey, () -> LimitedPoolResource.create(maxResources, Location.class, Location::new), true);
+      session.declareResources().add(queueKey, () -> new Queue(var, maxResources, concurrency, sequence, onCompletion), true);
+      session.declareResources().add(locationPoolKey, () -> LimitedPoolResource.create(maxResources, Location.class, Location::new), true);
    }
 
    /**

--- a/http/src/main/java/io/hyperfoil/http/html/HtmlHandler.java
+++ b/http/src/main/java/io/hyperfoil/http/html/HtmlHandler.java
@@ -199,7 +199,7 @@ public class HtmlHandler implements Processor, ResourceUtilizer, Session.Resourc
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(this, Context::new);
+      session.declareResources().add(this, Context::new);
    }
 
    public interface TagHandlerBuilder<S extends TagHandlerBuilder<S>> extends BuilderBase<S> {

--- a/http/src/main/java/io/hyperfoil/http/html/RefreshHandler.java
+++ b/http/src/main/java/io/hyperfoil/http/html/RefreshHandler.java
@@ -132,9 +132,11 @@ public class RefreshHandler implements Processor, ResourceUtilizer {
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(poolKey, () -> LimitedPoolResource.create(concurrency, Redirect.Coords.class, Redirect.Coords::new), true);
-      session.declareResource(immediateQueueKey, () -> new Queue(immediateQueueVar, concurrency, concurrency, redirectSequence, null), true);
-      session.declareResource(delayedQueueKey, () -> new Queue(delayedQueueVar, concurrency, concurrency, delaySequence, null), true);
+      session.declareResources()
+                  .ensureCapacity(3)
+                  .add(poolKey, () -> LimitedPoolResource.create(concurrency, Redirect.Coords.class, Redirect.Coords::new), true)
+                  .add(immediateQueueKey, () -> new Queue(immediateQueueVar, concurrency, concurrency, redirectSequence, null), true)
+                  .add(delayedQueueKey, () -> new Queue(delayedQueueVar, concurrency, concurrency, delaySequence, null), true);
       initQueueVar(session, immediateQueueVar);
       initQueueVar(session, delayedQueueVar);
    }

--- a/http/src/main/java/io/hyperfoil/http/steps/BeforeSyncRequestStep.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/BeforeSyncRequestStep.java
@@ -16,6 +16,6 @@ class BeforeSyncRequestStep implements Step, ResourceUtilizer, Session.ResourceK
    @Override
    public void reserve(Session session) {
       int concurrency = session.currentSequence().definition().concurrency();
-      session.declareResource(this, () -> BitSetResource.with(concurrency), true);
+      session.declareResources().add(this, () -> BitSetResource.with(concurrency), true);
    }
 }

--- a/http/src/main/java/io/hyperfoil/http/steps/PrepareHttpRequestStep.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/PrepareHttpRequestStep.java
@@ -136,6 +136,6 @@ public class PrepareHttpRequestStep extends StatisticsStep implements ResourceUt
 
    @Override
    public void reserve(Session session) {
-      session.declareResource(contextKey, HttpRequestContext::new);
+      session.declareResources().add(contextKey, HttpRequestContext::new);
    }
 }

--- a/http/src/test/java/io/hyperfoil/http/BaseClientTest.java
+++ b/http/src/test/java/io/hyperfoil/http/BaseClientTest.java
@@ -103,6 +103,7 @@ public class BaseClientTest extends VertxBaseTest {
    protected void sendRequestAndAssertStatus(TestContext ctx, HttpClientPool client, Async async, HttpMethod method, String path, int expectedStatus) {
       Session session = SessionFactory.forTesting();
       HttpRunData.initForTesting(session);
+      session.declareResources().build();
       HttpRequest request = HttpRequestPool.get(session).acquire();
       AtomicBoolean statusReceived = new AtomicBoolean(false);
       HttpResponseHandlers handlers = HttpResponseHandlersImpl.Builder.forTesting()

--- a/http/src/test/java/io/hyperfoil/http/BigResponseParsingTest.java
+++ b/http/src/test/java/io/hyperfoil/http/BigResponseParsingTest.java
@@ -93,6 +93,7 @@ public class BigResponseParsingTest extends VertxBaseTest {
          HttpClientPool client = result.result();
          Session session = SessionFactory.forTesting();
          HttpRunData.initForTesting(session);
+         session.declareResources().build();
          HttpResponseHandlers handlers = HttpResponseHandlersImpl.Builder.forTesting()
                .rawBytes(new RawBytesHandler() {
                   @Override

--- a/http/src/test/java/io/hyperfoil/http/CertificatesTest.java
+++ b/http/src/test/java/io/hyperfoil/http/CertificatesTest.java
@@ -157,6 +157,7 @@ public class CertificatesTest {
    private static void sendPingAndReceiveStatus(TestContext context, HttpServer server, HttpClientPool client, Async async, Integer expectedStatus) {
       Session session = SessionFactory.forTesting();
       HttpRunData.initForTesting(session);
+      session.declareResources().build();
       HttpRequest request = HttpRequestPool.get(session).acquire();
       AtomicBoolean statusReceived = new AtomicBoolean(false);
       HttpResponseHandlers handlers = HttpResponseHandlersImpl.Builder.forTesting()

--- a/http/src/test/java/io/hyperfoil/http/HttpCacheTest.java
+++ b/http/src/test/java/io/hyperfoil/http/HttpCacheTest.java
@@ -278,6 +278,7 @@ public class HttpCacheTest extends VertxBaseTest {
                   cleanup.add(client::shutdown);
                   context.session = SessionFactory.forTesting();
                   HttpRunData.initForTesting(context.session, CLOCK, cacheEnabled);
+                  context.session.declareResources().build();
                   context.pool = client;
                   context.requests.poll().run();
                });

--- a/http/src/test/java/io/hyperfoil/http/HttpClientPoolHandlerTest.java
+++ b/http/src/test/java/io/hyperfoil/http/HttpClientPoolHandlerTest.java
@@ -88,6 +88,7 @@ public class HttpClientPoolHandlerTest {
       pool.executor().execute(() -> {
          Session session = SessionFactory.forTesting();
          HttpRunData.initForTesting(session);
+         session.declareResources().build();
          HttpRequest request = HttpRequestPool.get(session).acquire();
          HttpResponseHandlersImpl handlers = HttpResponseHandlersImpl.Builder.forTesting()
                .status((r, code) -> {

--- a/http/src/test/java/io/hyperfoil/http/MemoryUsageTest.java
+++ b/http/src/test/java/io/hyperfoil/http/MemoryUsageTest.java
@@ -69,6 +69,7 @@ public class MemoryUsageTest {
             client.start(context.asyncAssertSuccess(nil -> {
                Session session = SessionFactory.forTesting();
                HttpRunData.initForTesting(session);
+               session.declareResources().build();
                HttpConnectionPool pool = client.next();
                doRequest(pool, session, context, async, seenMemoryUsage);
             }));

--- a/http/src/test/java/io/hyperfoil/http/RawBytesHandlerTest.java
+++ b/http/src/test/java/io/hyperfoil/http/RawBytesHandlerTest.java
@@ -58,6 +58,7 @@ public class RawBytesHandlerTest extends VertxBaseTest {
                   cleanup.add(client::shutdown);
                   Session session = SessionFactory.forTesting();
                   HttpRunData.initForTesting(session);
+                  session.declareResources().build();
                   AtomicReference<HttpResponseHandlers> handlersRef = new AtomicReference<>();
                   handlersRef.set(HttpResponseHandlersImpl.Builder.forTesting()
                         .rawBytes(new RawBytesHandler() {

--- a/http/src/test/java/io/hyperfoil/http/handlers/SearchValidatorTest.java
+++ b/http/src/test/java/io/hyperfoil/http/handlers/SearchValidatorTest.java
@@ -71,6 +71,7 @@ public class SearchValidatorTest {
       Session session = SessionFactory.forTesting();
       ResourceUtilizer.reserveForTesting(session, validator);
       HttpRunData.initForTesting(session);
+      session.declareResources().build();
       HttpRequest request = HttpRequestPool.get(session).acquire();
       request.start(new SequenceInstance(), null);
       session.currentRequest(request);

--- a/http/src/test/java/io/hyperfoil/http/html/MetaRefreshHandlerTest.java
+++ b/http/src/test/java/io/hyperfoil/http/html/MetaRefreshHandlerTest.java
@@ -21,6 +21,7 @@ public class MetaRefreshHandlerTest {
       Session session = SessionFactory.forTesting();
       HttpRunData.initForTesting(session);
       ResourceUtilizer.reserveForTesting(session, handler);
+      session.declareResources().build();
       handler.before(session);
 
       ByteBuf content1 = buf("content1");


### PR DESCRIPTION
This is a suggested direction for #386 NOT to shrink the existing resources (although it does it - see the TODO for the missing pieces there), but more to have an API where we can be more declarative in term of Session's setup/reservation accepted lifecycle.
If the original intent of Hyperfoil is to reserve pooled instances upfront, I think would be nice to be declarative about such and even "freeze" the `Session` from changes when is not expected.
This PR is proposing a direction in this: narrowing the lifecycle phases for `Session` enable optimizations for the phases we care the most; is just impossible to make things just better in every context.