### PR TITLE
Better tune calibration wrk2 phase by lowering maxSessions

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/Wrk.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Wrk.java
@@ -43,7 +43,8 @@ public class Wrk extends WrkAbstract {
    public class WrkCommand extends WrkAbstract.AbstractWrkCommand {
 
       @Override
-      protected PhaseBuilder<?> phaseConfig(PhaseBuilder.Catalog catalog) {
+      protected PhaseBuilder<?> phaseConfig(PhaseBuilder.Catalog catalog, PhaseType phaseType, long durationMs) {
+         // there's no need of sessions != connections
          return catalog.always(connections);
       }
    }

--- a/cli/src/main/java/io/hyperfoil/cli/commands/Wrk2.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Wrk2.java
@@ -47,10 +47,18 @@ public class Wrk2 extends WrkAbstract {
       int rate;
 
       @Override
-      protected PhaseBuilder<?> phaseConfig(PhaseBuilder.Catalog catalog) {
+      protected PhaseBuilder<?> phaseConfig(PhaseBuilder.Catalog catalog, PhaseType phaseType, long durationMs) {
+         int durationSeconds = (int) Math.ceil(durationMs / 1000);
+         int maxSessions =
+               switch (phaseType) {
+                  // given that the duration of this phase is 6s seconds
+                  // there's no point to have more than 6 * rate sessions
+                  case calibration -> rate * durationSeconds;
+                  case test -> rate * 15;
+               };
          return catalog.constantRate(rate)
                .variance(false)
-               .maxSessions(rate * 15);
+               .maxSessions(maxSessions);
       }
 
    }


### PR DESCRIPTION
This is just better tuning the calibration phase of Wrk2 to not use that many sessions, given that they won't be reused
for the test phase, and will still be resident in the old gen of the heap :"(

Simple workaround while waiting #389 to be addressed.

I've adopted the safest possible value here, to avoid missing sessions.
