### PR TITLE
Add documentation for useHttpCache property

### DIFF
--- a/docs/site/content/en/docs/user-guide/benchmark/http.md
+++ b/docs/site/content/en/docs/user-guide/benchmark/http.md
@@ -45,6 +45,7 @@ HTTP configuration has these properties:
 | rawBytesHandlers  | true    | Enable or disable using handlers that process HTTP response raw bytes. |
 | [keyManager](#keymanager-configuration) |         | TLS key manager for setting up client certificates. |
 | [trustManager](#trustmanager-configuration) |         | TLS trust manager for setting up server certificates. |
+| useHttpCache      | true    | Make use of HTTP cache on client-side. If multiple authorities are involved, disable the HTTP cache for all of them to achieve the desired outcomes. The default is `true` except for wrk/wrk2 wrappers where it is set to `false`. |
 
 ## Shared connections
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

Add documentation for the new `useHttpCache` property which has been introduced with https://github.com/Hyperfoil/Hyperfoil/pull/375

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>