### PR TITLE
[0.26.x] docs: fix publish date for past blogs

### DIFF
--- a/docs/site/content/en/blog/news/2021-02-09-hf-beginner-guide-2.md
+++ b/docs/site/content/en/blog/news/2021-02-09-hf-beginner-guide-2.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-01-25
+date: 2021-02-09
 title: "Beginner's Guide to Hyperfoil: part 2"
 linkTitle: "Beginner's Guide 2"
 description: >

--- a/docs/site/content/en/blog/news/2021-02-16-hf-beginner-guide-3/index.md
+++ b/docs/site/content/en/blog/news/2021-02-16-hf-beginner-guide-3/index.md
@@ -1,5 +1,5 @@
 ---
-date: 2021-01-25
+date: 2021-02-16
 title: "Beginner's Guide to Hyperfoil: part 3"
 linkTitle: "Beginner's Guide 3"
 type: blog


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Hyperfoil/pull/396

<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

Fix the publish date for the past beginner guides.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>