### PR TITLE
Skip build if changing only docs and txt files

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -17,6 +17,7 @@ on:
       - "**.txt"
       - ".github/ISSUE_TEMPLATE/**"
       - ".github/dependabot.yml"
+      - "docs/**"
 
 jobs:
   build-image:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,14 @@ on:
     tags: [ "*" ]
   pull_request:
     branches: [ master ]
+    paths-ignore:
+    - "LICENSE*"
+    - "**.gitignore"
+    - "**.md"
+    - "**.txt"
+    - ".github/ISSUE_TEMPLATE/**"
+    - ".github/dependabot.yml"
+    - "docs/**"
 
 jobs:
   build:


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Hyperfoil/issues/397

## Changes proposed

Skip the java build when the PR just contains docs-related changes
Skip container image build/push from `master` pushes for the same reason

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>