### PR TITLE
Skip benchmark validation run on wrk/wrk2

### DIFF
--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
@@ -213,7 +213,10 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
                      ControllerPhase controllerPhase = run.phases.get(pscm.phase);
                      if (controllerPhase != null) {
                         tryCompletePhase(run, pscm.phase, controllerPhase);
-                     } else {
+                     } else if (!run.validation) {
+                        // if run.validation is true, then startSimulation is not executed and the phases are not
+                        // added in the list, therefore it is expected that the phase is not found
+                        // log the error if and only if the phase is not found, and we are not running just validation
                         log.error("Run {}: Cannot find phase {}!", run.id, pscm.phase);
                      }
                   }

--- a/controller-api/src/main/java/io/hyperfoil/controller/HistogramConverter.java
+++ b/controller-api/src/main/java/io/hyperfoil/controller/HistogramConverter.java
@@ -21,7 +21,7 @@ public final class HistogramConverter {
       writer.outputIntervalHistogram(source);
       writer.close();
       return new Histogram(phase, metric, source.getStartTimeStamp(), source.getEndTimeStamp(),
-            new String(bos.toByteArray(), StandardCharsets.UTF_8));
+            bos.toString(StandardCharsets.UTF_8));
    }
 
    public static AbstractHistogram convert(Histogram source) {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Partially related to https://github.com/Hyperfoil/Hyperfoil/issues/389.

In the current implemention of `wrk` and `wrk2` wrappers, the command executed `2` different runs:
- #1: This is just a validation run, no actual simulation is performed https://github.com/Hyperfoil/Hyperfoil/blob/52df8711e34d214f6b34e6b1cb45419c158bb61c/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java#L160-L168
- #2: The second one is the real simulation run

This results in two runs stored:
![Screenshot from 2024-07-19 11-24-39](https://github.com/user-attachments/assets/918e3cc2-eba5-445a-98c5-28f2c2b0a386)

But, most importantly, the 2 runs are separated runs.. this means that the allocation is ~twice the expected one as we are creating two identical runs.

Given that the `wrk` benchmarks are pre-defined benchmarks, I don't see why we should run a validation-only run before running the simulation, but maybe I am missing something here.

## Changes proposed

Assuming my understanding is correct, I am proposing to remove the validation run which should reduce the used heap as only one run will be created.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>