### PR TITLE
Set provided scope to maven plugins dependencies

### DIFF
--- a/plugins/codegen/pom.xml
+++ b/plugins/codegen/pom.xml
@@ -21,6 +21,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>
@@ -40,6 +41,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>

--- a/plugins/maven/pom.xml
+++ b/plugins/maven/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>
@@ -64,6 +65,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes the following warning:
```
2024-08-07T09:41:35.3200650Z [WARNING] 
2024-08-07T09:41:35.3201481Z 
2024-08-07T09:41:35.3203190Z Some dependencies of Maven Plugins are expected to be in provided scope.
2024-08-07T09:41:35.3205024Z Please make sure that dependencies listed below declared in POM
2024-08-07T09:41:35.3206769Z have set '<scope>provided</scope>' as well.
2024-08-07T09:41:35.3207526Z 
2024-08-07T09:41:35.3208026Z The following dependencies are in wrong scope:
2024-08-07T09:41:35.3209147Z  * org.apache.maven:maven-plugin-api:jar:3.9.8:compile
2024-08-07T09:41:35.3278233Z  * org.apache.maven:maven-model:jar:3.9.8:compile
2024-08-07T09:41:35.3279499Z  * org.apache.maven:maven-artifact:jar:3.9.8:compile
2024-08-07T09:41:35.3280552Z  * org.apache.maven:maven-core:jar:3.9.8:compile
2024-08-07T09:41:35.3281779Z  * org.apache.maven:maven-settings:jar:3.9.8:compile
2024-08-07T09:41:35.3282979Z  * org.apache.maven:maven-settings-builder:jar:3.9.8:compile
2024-08-07T09:41:35.3283711Z  * org.apache.maven:maven-builder-support:jar:3.9.8:compile
2024-08-07T09:41:35.3284490Z  * org.apache.maven:maven-repository-metadata:jar:3.9.8:compile
2024-08-07T09:41:35.3285149Z  * org.apache.maven:maven-model-builder:jar:3.9.8:compile
2024-08-07T09:41:35.3286005Z  * org.apache.maven:maven-resolver-provider:jar:3.9.8:compile
```

## Changes proposed

- [x] Import maven plugins dependencies with the proper scope, i.e., `provided` as suggested by the warning.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>