### PR TITLE
Remove explicit jboss logging dependency

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -58,11 +58,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/clustering/src/main/java/io/hyperfoil/Hyperfoil.java
+++ b/clustering/src/main/java/io/hyperfoil/Hyperfoil.java
@@ -83,7 +83,8 @@ public class Hyperfoil {
             log.error("This machine is configured to resolve its hostname to 127.0.0.1; this is " +
                   "an invalid configuration for clustering. Make sure `hostname -i` does not return 127.0.0.1 or ::1 " +
                   " or set -D{}=x.x.x.x to use different address. " +
-                  "(if you set that to 127.0.0.1 you won't be able to connect from agents on other machines).", Properties.CONTROLLER_CLUSTER_IP);
+                  "(if you set that to 127.0.0.1 you won't be able to connect from agents on other machines).",
+                  Properties.CONTROLLER_CLUSTER_IP);
             return Future.failedFuture("Hostname resolves to 127.0.0.1");
          }
          // We are using numeric address because if this is running in a pod its hostname

--- a/hotrod/pom.xml
+++ b/hotrod/pom.xml
@@ -21,18 +21,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
             <version>${version.infinispan}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>com.github.ben-manes.caffeine</groupId>
                     <artifactId>caffeine</artifactId>
@@ -73,12 +65,6 @@
             <artifactId>infinispan-server-hotrod</artifactId>
             <version>${version.infinispan}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -93,12 +79,6 @@
             <version>${version.infinispan}</version>
             <type>test-jar</type>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -107,10 +87,6 @@
             <scope>test</scope>
             <type>test-jar</type>
             <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.wildfly.common</groupId>
                     <artifactId>wildfly-common</artifactId>
@@ -123,12 +99,6 @@
             <version>${version.infinispan}</version>
             <type>test-jar</type>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
@@ -136,10 +106,6 @@
             <version>${version.infinispan}</version>
             <scope>test</scope>
             <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>io.reactivex.rxjava3</groupId>
                     <artifactId>rxjava</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
         <version.vertx>4.5.4</version.vertx>
         <version.infinispan>15.0.6.Final</version.infinispan>
         <version.jboss-threads>3.5.0.Final</version.jboss-threads>
-        <version.jboss-logging>3.5.0.Final</version.jboss-logging>
         <version.wildfly-common>1.6.0.Final</version.wildfly-common>
         <version.jctools>4.0.5</version.jctools>
 
@@ -408,12 +407,6 @@
                         <artifactId>wildfly-common</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.jboss-logging}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

JBoss logging is not used in Hyperfoil codebase, thus we should safely remove and inherit it from inifinispan hotrod dependencies.

This will make https://github.com/Hyperfoil/Hyperfoil/pull/421 no longer required.

## Changes proposed

- [x] Remove explicit `org.jboss.logging:jboss-logging` dependency

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>