### PR TITLE
Exclude jboss-logging from jboss-threads

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -43,6 +43,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-infinispan</artifactId>
             <exclusions>
@@ -55,11 +60,6 @@
                     <artifactId>jboss-threads</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
         </dependency>
 
         <dependency>
@@ -138,6 +138,12 @@
         <dependency>
             <groupId>org.jboss.threads</groupId>
             <artifactId>jboss-threads</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/clustering/src/main/java/io/hyperfoil/Hyperfoil.java
+++ b/clustering/src/main/java/io/hyperfoil/Hyperfoil.java
@@ -83,7 +83,8 @@ public class Hyperfoil {
             log.error("This machine is configured to resolve its hostname to 127.0.0.1; this is " +
                   "an invalid configuration for clustering. Make sure `hostname -i` does not return 127.0.0.1 or ::1 " +
                   " or set -D{}=x.x.x.x to use different address. " +
-                  "(if you set that to 127.0.0.1 you won't be able to connect from agents on other machines).", Properties.CONTROLLER_CLUSTER_IP);
+                  "(if you set that to 127.0.0.1 you won't be able to connect from agents on other machines).",
+                  Properties.CONTROLLER_CLUSTER_IP);
             return Future.failedFuture("Hostname resolves to 127.0.0.1");
          }
          // We are using numeric address because if this is running in a pod its hostname


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

- [x] Properly exclude `jboss-logging` from `jboss-threads` source.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>