### PR TITLE
docs: fix quickstart links

### DIFF
--- a/docs/site/content/en/docs/getting-started/quickstart2.md
+++ b/docs/site/content/en/docs/getting-started/quickstart2.md
@@ -6,7 +6,7 @@ tags: [quickstart, steps, statistics]
 weight: 2
 ---
 
-In [previous quickstart](/docs/getting-started/quickstart2) you created a benchmark
+In [previous quickstart](/docs/getting-started/quickstart1) you created a benchmark
 that fires only one HTTP request. Our next example is going to hit random URLs at this server with 10 requests per second. We'll see how to generate random data and collect statistics for different URLs.
 
 Let's start a container that will serve the requests:

--- a/docs/site/content/en/docs/getting-started/quickstart3.md
+++ b/docs/site/content/en/docs/getting-started/quickstart3.md
@@ -6,7 +6,7 @@ tags: [quickstart]
 weight: 3
 ---
 
-The [previous example](/docs/getting-started/quickstart) was the first 'real' benchmark, but it didn't do anything different from what you could run through `wrk`, `ab`, `siege` or similar tools.
+The [previous example](/docs/getting-started/quickstart2) was the first 'real' benchmark, but it didn't do anything different from what you could run through `wrk`, `ab`, `siege` or similar tools.
 
 Of course, the results were not suffering from the _coordinated omission problem_, but Hyperfoil can do more. Let's try a more complex scenario:
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

Fix website quickstart links.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>