### PR TITLE
Upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
+    # setup local ssh key for benchmark tests
     - name: Generate SSH keys
       run: ssh-keygen -t rsa -b 4096 -C "github@hyperfoil.io" -f ~/.ssh/id_rsa
     - name: Authorize SSH key on localhost
@@ -42,10 +43,10 @@ jobs:
       run: ssh-keyscan localhost >> ~/.ssh/known_hosts
     - name: Fix home dir permissions
       run: chmod go-w /home/$USER && chmod 700 /home/$USER/.ssh && chmod 600 /home/$USER/.ssh/authorized_keys
+    # Run a full build with all tests
     - name: Build with Maven
       run: mvn clean -B package --file pom.xml -Pbenchmark -Pbuild-image -Dio.hyperfoil.agent.java.executable=$JAVA_HOME/bin/java $NO_DOWNLOAD_MESSAGE -Dagent.log.trace
     - name: Check uncommitted changes
-      if: matrix.os.name == 'ubuntu-latest'
       run: |
         clean=$(git status --porcelain)
         if [[ -z "$clean" ]]; then
@@ -57,9 +58,9 @@ jobs:
         fi
     - name: Upload artifact for failed workflow
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: test logs
+        name: tests_logs
         path: |
           */target/surefire-reports/*
           test-suite/target/hyperfoil/*.log


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes warning reported in the latest CI builds:

![image](https://github.com/user-attachments/assets/4a6d0d57-afe2-4929-b303-460f5c9a54e5)

Reference: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Changes proposed

Upgrade the `actions/upload-artifact` to version `v4`

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>