### PR TITLE
Fix BaseHttpScenarioTest initWithServer

### DIFF
--- a/http/src/test/java/io/hyperfoil/http/BaseHttpScenarioTest.java
+++ b/http/src/test/java/io/hyperfoil/http/BaseHttpScenarioTest.java
@@ -70,7 +70,7 @@ public abstract class BaseHttpScenarioTest extends BaseScenarioTest {
       server = vertx.createHttpServer(options)
             .requestHandler(router)
             .listen(0, "localhost", ctx.succeeding(srv -> {
-               initWithServer(tls);
+               initWithServer(srv, tls);
                promise.complete();
                ctx.completeNow();
             }));
@@ -86,12 +86,12 @@ public abstract class BaseHttpScenarioTest extends BaseScenarioTest {
       return false;
    }
 
-   protected void initWithServer(boolean tls) {
+   protected void initWithServer(HttpServer srv, boolean tls) {
       HttpPluginBuilder httpPlugin = benchmarkBuilder.plugin(HttpPluginBuilder.class);
       HttpBuilder http = httpPlugin.http();
       http.protocol(tls ? Protocol.HTTPS : Protocol.HTTP)
             .name("myhost")
-            .host("localhost").port(server.actualPort());
+            .host("localhost").port(srv.actualPort());
       initHttp(http);
    }
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Hyperfoil/issues/458

## Changes proposed

- [x] Pass the `HttpServer` instance to the `initWithServer` method instead of relying to the global `server` field (which might not be assigned where queried)

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>