### PR TITLE
docs: fix Github website links

### DIFF
--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -174,7 +174,7 @@ params:
     # End user relevant links. These will show up on left side of footer and in the community page if you have one.
     user:
       - name: GitHub Discussions
-        url: https://github.com/Hyperfoil/Hyperofil/discussions
+        url: https://github.com/Hyperfoil/Hyperfoil/discussions
         icon: fab fa-github
         desc: If you have a question, please ask the Hyperfoil team
       - name: Twitter
@@ -184,7 +184,7 @@ params:
     # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
     developer:
       - name: GitHub
-        url: https://github.com/Hyperfoil/Hyperofil
+        url: https://github.com/Hyperfoil/Hyperfoil
         icon: fab fa-github
         desc: Development takes place here!
       - name: Zulip
@@ -192,7 +192,7 @@ params:
         icon: fab fa-z
         desc: Chat with other Hyperfoil developers
       - name: GitHub Issues
-        url: https://github.com/Hyperfoil/Hyperofil/issues
+        url: https://github.com/Hyperfoil/Hyperfoil/issues
         icon: fab fa-github
         desc: If you find a bug, or want to suggest a new feature!
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes a typo in the Github links that are set in the Hyperfoil website

## Changes proposed

- [x] Fix typo

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>