### PR TITLE
Fix session package javadoc

### DIFF
--- a/core/src/main/java/io/hyperfoil/core/session/package-info.java
+++ b/core/src/main/java/io/hyperfoil/core/session/package-info.java
@@ -1,12 +1,12 @@
 /**
- * <h1>Design</h1>
+ * <h2>Design</h2>
  * <p>
  * There are two main components:
  * <ul>
  * <li>{@link io.hyperfoil.api.config.Sequence Sequence templates} - instructions 'what to do'
  * <li>Session (execution context) holds any state, including current state of the state machine and variables
  * </ul>
- * <h2>Memory allocation</h2>
+ * <h3>Memory allocation</h3>
  * <p>
  * In order to keep object allocations at minimum we're expected to know all variables in advance and pre-allocate
  * these in the Session object. During consecutive repetitions of the user scenario
@@ -19,7 +19,7 @@
  * which in turn calls this on all {@link io.hyperfoil.api.config.Step steps} and these call the
  * {@link io.hyperfoil.api.processor.Processor processors} or any other handlers.
  *
- * <h2>Execution</h2>
+ * <h3>Execution</h3>
  * <p>
  * After the session is constructed or reset you should create {@link io.hyperfoil.api.session.SequenceInstance sequence
  * instances}
@@ -39,7 +39,7 @@
  * <p>
  * Execution is terminated when there are no enabled sequences in the session.
  *
- * <h2>Variables</h2>
+ * <h3>Variables</h3>
  * <p>
  * The {@link io.hyperfoil.api.session.Session} is provided as a parameter to most calls and stores all state of the scenario.
  * The state is operated using "accessors"; these can be retrieved from
@@ -62,7 +62,7 @@
  * The choice of index is up to the Step that creates the new sequences. Two concurrently enabled sequences may share
  * the same index, but in that case these should not use the same variable names for sequence-scoped data.
  *
- * <h2>Threading model</h2>
+ * <h3>Threading model</h3>
  * <p>
  * There's no internal synchronization of anything; we rely on the event-loop model.
  * Each {@link io.hyperfoil.api.session.Session session} is tied to a single-threaded {@link io.netty.channel.EventLoop event


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes an issue reported during the Hyperfoil release, in particular:
```
on project hyperfoil-core: MavenReportException: Error while generating Javadoc: 
[ERROR] Exit code: 1
[ERROR] /home/alampare/repos/Hyperfoil/core/src/main/java/io/hyperfoil/core/session/package-info.java:2: error: unexpected heading used: <H1>, compared to implicit preceding heading: <H1>
[ERROR]  * <h1>Design</h1>
[ERROR]    ^
```

## Changes proposed

The javadoc should start from `<h2>` as there is an implicit `<h1>`.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>