### PR TITLE
[0.27.x] Add 0.27 release note in the website

### DIFF
--- a/docs/site/content/en/blog/releases/release_notes.md
+++ b/docs/site/content/en/blog/releases/release_notes.md
@@ -5,6 +5,30 @@ type: docs
 weight: 1
 ---
 
+## 0.27 (2024-10-22)
+
+* Upgrade to JDK 17
+* Extends max sequences and requests wrk settings to HTTP 2 as well
+* Fixes #385 Optimize 0 and 1 Sequence's concurrency on HTTP
+* Better tune calibration wrk2 phase
+* Avoid byte[] allocation per event object
+* Export standard deviation for response time
+* Add max response time in CLI stats
+* Rate generators refactoring and compensation unification
+* Add simulation initialization time log
+* Make HTTP cache configurable
+* Skip benchmark validation run on wrk/wrk2
+* Rate generators session pool workstealing
+* Reduce maxRequests to 1 for Wrk HTTP 1.1
+* Add utility hyperfoil run script
+* Replace HyperfoilChannelLookup
+* Bump version.infinispan from 15.0.8.Final
+* Bump org.jboss.logging:jboss-logging to 3.6.0.Final
+* Bump org.yaml:snakeyaml to 2.2
+* Fix incorrect log messages
+* Migrate tests to junit 5
+* Generic improvements in the CI
+
 ## 0.26 (2024-05-31)
 
 * Remove java.net.preferIPv4Stack=true


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Hyperfoil/pull/486

<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

- [x] Add website release notes for hyperfoil `0.27` release

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>