### PR TITLE
[0.27.x] docs: fix local log path

### DIFF
--- a/docs/site/content/en/docs/user-guide/troubleshooting.md
+++ b/docs/site/content/en/docs/user-guide/troubleshooting.md
@@ -10,7 +10,7 @@ weight: 5
 
 The first step to identifying any issue is getting a verbose log - setting logging level to TRACE. How exactly you do that depends on the way you deploy Hyperfoil:
 
-1. If you use CLI and the `start-local` command, just run it as `start-local -l TRACE` which sets the default logging level. You'll find the log in `/tmp/hyperfoil.local.log` by default.
+1. If you use CLI and the `start-local` command, just run it as `start-local -l TRACE` which sets the default logging level. You'll find the log in `/tmp/hyperfoil/hyperfoil.local.log` by default.
 
 2. If you run Hyperfoil manually in [standalone mode](/docs/user-guide/installation/start_manual/) (non-clustered) the agent will run in the same JVM as the controller. You need to add `-Dlog4j.configurationFile=file:///path/to/log4j2-trace.xml` option when starting `standalone.sh`. If you start Hyperfoil through Ansible the same is set using `hyperfoil_log_config` variable.
 


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Hyperfoil/pull/489

<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes the local log path that is referenced in the website documentation.

Replace old https://github.com/Hyperfoil/hyperfoil.github.io/pull/44

## Changes proposed

- [x] Fix `/tmp/hyperfoil.local.log` to `/tmp/hyperfoil/hyperfoil.local.log`

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>