### PR TITLE
Add run persistence monitoring

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/Wait.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Wait.java
@@ -18,6 +18,7 @@ public class Wait extends BaseRunIdCommand {
 
    private boolean started = false;
    private boolean terminated = false;
+   private boolean persisted = false;
 
    @Override
    public CommandResult execute(HyperfoilCommandInvocation invocation) throws CommandException, InterruptedException {
@@ -47,6 +48,14 @@ public class Wait extends BaseRunIdCommand {
                }
             }
             invocation.context().notifyRunCompleted(run);
+         }
+
+         // right now if for some reason the run.persisted is not set to true, the process will wait forever.
+         // we could implement a timeout to be safe
+         if (terminated && !persisted && run.persisted) {
+            // this monitoring will guarantee that if we try to run the report, the all.json is already persisted
+            persisted = true;
+            invocation.println("Run persisted in the local filesystem");
             return CommandResult.SUCCESS;
          }
 

--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerServer.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerServer.java
@@ -687,8 +687,8 @@ class ControllerServer implements ApiService {
    public void listRuns(RoutingContext ctx, boolean details) {
       io.hyperfoil.controller.model.Run[] runs = controller.runs().stream()
             .map(r -> details ? runInfo(r, false)
-                  : new io.hyperfoil.controller.model.Run(r.id, null, null, null, r.cancelled, r.completed, null, null, null,
-                        null))
+                  : new io.hyperfoil.controller.model.Run(r.id, null, null, null, r.cancelled,
+                        r.completed, r.persisted, null, null, null, null))
             .toArray(io.hyperfoil.controller.model.Run[]::new);
       respondWithJson(ctx, true, runs);
    }
@@ -757,7 +757,7 @@ class ControllerServer implements ApiService {
             .map(ai -> new io.hyperfoil.controller.model.Agent(ai.name, ai.deploymentId, ai.status.toString()))
             .collect(Collectors.toList());
       return new io.hyperfoil.controller.model.Run(run.id, benchmark, started, terminated, run.cancelled, run.completed,
-            run.description, phases, agents,
+            run.persisted, run.description, phases, agents,
             run.errors.stream().map(Run.Error::toString).collect(Collectors.toList()));
    }
 

--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
@@ -532,6 +532,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       }
    }
 
+   @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
    String startBenchmark(Run run, Boolean validation) {
       Set<String> activeAgents = new HashSet<>();
       for (Run r : runs.values()) {
@@ -638,6 +639,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       }
    }
 
+   @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
    private void startSimulation(Run run) {
       vertx.executeBlocking(future -> {
          // combine shared and benchmark-private hooks
@@ -786,6 +788,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       }
    }
 
+   @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
    private void persistRun(Run run) {
       vertx.executeBlocking(future -> {
          try {
@@ -815,7 +818,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
                      .collect(Collectors.toList())));
 
          try {
-            Files.write(run.dir.resolve("info.json"), info.encodePrettily().getBytes(StandardCharsets.UTF_8));
+            Files.writeString(run.dir.resolve("info.json"), info.encodePrettily());
          } catch (IOException e) {
             log.error("Cannot write info file", e);
             future.fail(e);
@@ -852,7 +855,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
                .map(r -> new JsonObject().put("name", r.name).put("output", r.output))
                .collect(Collectors.toList()));
          try {
-            Files.write(run.dir.resolve("hooks.json"), hookResults.encodePrettily().getBytes(StandardCharsets.UTF_8));
+            Files.writeString(run.dir.resolve("hooks.json"), hookResults.encodePrettily());
          } catch (IOException e) {
             log.error("Cannot write hook results", e);
             future.fail(e);
@@ -861,6 +864,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
          future.tryComplete();
       }, result -> {
          run.completed = true;
+         run.persisted = true;
          if (result.failed()) {
             log.error("Failed to persist run {}", run.id, result.cause());
          } else {
@@ -914,6 +918,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       }
    }
 
+   @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
    public Future<Void> addBenchmark(Benchmark benchmark, String prevVersion) {
       if (prevVersion != null) {
          Benchmark prev = benchmarks.get(benchmark.name());
@@ -940,6 +945,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       });
    }
 
+   @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
    public Future<Void> addTemplate(BenchmarkSource template, String prevVersion) {
       if (prevVersion != null) {
          BenchmarkSource prev = templates.get(template.name);
@@ -980,6 +986,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       return templates.get(name);
    }
 
+   @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
    private void loadBenchmarks(Handler<AsyncResult<Void>> handler) {
       vertx.executeBlocking(future -> {
          try {
@@ -1089,6 +1096,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       return deployer != null && deployer.hasControllerLog();
    }
 
+   @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
    public void downloadControllerLog(long offset, File tempFile, Handler<AsyncResult<Void>> handler) {
       vertx.executeBlocking(future -> deployer.downloadControllerLog(offset, tempFile.toString(), handler), result -> {
          if (result.failed()) {
@@ -1097,6 +1105,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       });
    }
 
+   @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
    public void downloadAgentLog(DeployedAgent deployedAgent, long offset, File tempFile, Handler<AsyncResult<Void>> handler) {
       vertx.executeBlocking(future -> deployer.downloadAgentLog(deployedAgent, offset, tempFile.toString(), handler),
             result -> {

--- a/clustering/src/main/java/io/hyperfoil/clustering/Run.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/Run.java
@@ -30,6 +30,8 @@ class Run {
    Promise<Long> terminateTime = Promise.promise();
    boolean cancelled;
    boolean completed;
+   // set to true once the all.json and related files are persisted in the filesystem
+   boolean persisted;
    boolean validation;
    Supplier<StatisticsStore> statsSupplier;
    private StatisticsStore statisticsStore;

--- a/controller-api/src/main/resources/openapi.yaml
+++ b/controller-api/src/main/resources/openapi.yaml
@@ -774,6 +774,7 @@ components:
       - benchmark
       - started
       - terminated
+      - persisted
       properties:
         id:
           type: string
@@ -792,6 +793,8 @@ components:
         cancelled:
           type: boolean
         completed:
+          type: boolean
+        persisted:
           type: boolean
         description:
           type: string


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Hyperfoil/issues/491

## Changes proposed

- [x] Added `persisted` boolean in the API run object to keep track if the persistence occurred or not
- [x] The `Wait` command monitors the `persisted` state before completing

With these changes, the report is triggered only once the `all.json` is actually created.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>