### PR TITLE
Run CI on stable branch as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,13 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ master ]
-    tags: [ "*" ]
+    branches:
+      - master
+      - 0.27.x
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - 0.27.x
     paths-ignore:
     - "LICENSE*"
     - "**.gitignore"


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

- [x] Run the CI on `master` and on the current _stable_ branch (right now `0.27.x`)
- [x] Do not run `main.yml` on tag push as the CI is already run as part of the `build-and-push.yml`

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>