### PR TITLE
ci: user correct release name during release generation

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -93,7 +93,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag_name: ${{ github.ref }}
-        name: Release ${{ env.PROJECT_VERSION }}
+        name: hyperfoil-all-${{ env.PROJECT_VERSION }}
         draft: false
         prerelease: false
         generate_release_notes: true


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Currently the Github release workflow generates a release with name `Release <VERSION>`, which is not the one we want.

Changing it to `hyperfoil-all-<VERSION>`.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>