### PR TITLE
[0.27.x] Add useHttpCache in the benchmark JSON schema

### DIFF
--- a/distribution/src/main/java/io/hyperfoil/schema/Generator.java
+++ b/distribution/src/main/java/io/hyperfoil/schema/Generator.java
@@ -3,7 +3,6 @@ package io.hyperfoil.schema;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -128,12 +127,12 @@ public class Generator extends BaseGenerator {
          addBuilder(builders, simpleBuilders, entry.getKey(), implClazz, InitFromParam.class.isAssignableFrom(implClazz));
       }
 
-      if (simpleBuilders.size() == 0) {
+      if (simpleBuilders.isEmpty()) {
          oneOf.remove(1);
       }
       definitions.forEach(e -> schemaDefinitions.put(e.getKey(), e.getValue()));
 
-      Files.write(output, schema.encodePrettily().getBytes(StandardCharsets.UTF_8));
+      Files.writeString(output, schema.encodePrettily());
    }
 
    private void addBuilder(JsonObject builders, JsonArray simpleBuilders, String name, Class<?> builder, boolean inline) {
@@ -142,7 +141,7 @@ public class Generator extends BaseGenerator {
          JsonObject step = new JsonObject();
          definitions.put(builder.getName(), step);
          describeBuilder(builder, step, properties);
-         if (properties.size() == 0) {
+         if (properties.isEmpty()) {
             simpleBuilders.add(name);
          }
       }

--- a/distribution/src/main/resources/schema.json
+++ b/distribution/src/main/resources/schema.json
@@ -344,6 +344,10 @@
             "password" : { "type" : "string" },
             "certFile" : { "type" : "string" }
           }
+        },
+        "useHttpCache": {
+          "description": "Make use of HTTP cache on client-side. If multiple authorities are involved, disable the HTTP cache for all of them to achieve the desired outcomes. The default is true except for wrk/wrk2 wrappers where it is set to false.\n",
+          "type": "boolean"
         }
       }
     },

--- a/docs/site/static/schema.json
+++ b/docs/site/static/schema.json
@@ -359,6 +359,10 @@
               "type" : "string"
             }
           }
+        },
+        "useHttpCache" : {
+          "description" : "Make use of HTTP cache on client-side. If multiple authorities are involved, disable the HTTP cache for all of them to achieve the desired outcomes. The default is true except for wrk/wrk2 wrappers where it is set to false.\n",
+          "type" : "boolean"
         }
       }
     },


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Hyperfoil/pull/510

<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Add missing `useHttpCache` configuration in the Benchmark JSON schema.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>