### PR TITLE
Remove validation run logic

### DIFF
--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerServer.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerServer.java
@@ -535,7 +535,7 @@ class ControllerServer implements ApiService {
 
    @Override
    public void startBenchmark(RoutingContext ctx, String name, String desc, String xTriggerJob, String runId,
-         List<String> templateParam, boolean validate) {
+         List<String> templateParam) {
       Benchmark benchmark = controller.getBenchmark(name);
       if (benchmark == null) {
          BenchmarkSource template = controller.getTemplate(name);
@@ -551,7 +551,7 @@ class ControllerServer implements ApiService {
       String triggerUrl = benchmark.triggerUrl() != null ? benchmark.triggerUrl() : TRIGGER_URL;
       if (triggerUrl != null) {
          if (xTriggerJob == null) {
-            Run run = controller.createRun(benchmark, desc, validate);
+            Run run = controller.createRun(benchmark, desc);
             if (!triggerUrl.endsWith("&") && !triggerUrl.endsWith("?")) {
                if (triggerUrl.contains("?")) {
                   triggerUrl = triggerUrl + "&";
@@ -569,7 +569,7 @@ class ControllerServer implements ApiService {
       }
       Run run;
       if (runId == null) {
-         run = controller.createRun(benchmark, desc, validate);
+         run = controller.createRun(benchmark, desc);
       } else {
          run = controller.run(runId);
          if (run == null || run.startTime != Long.MIN_VALUE) {
@@ -577,7 +577,7 @@ class ControllerServer implements ApiService {
             return;
          }
       }
-      String error = controller.startBenchmark(run, validate);
+      String error = controller.startBenchmark(run);
       if (error == null) {
          ctx.response().setStatusCode(HttpResponseStatus.ACCEPTED.code())
                .putHeader(HttpHeaders.LOCATION, baseURL + "/run/" + run.id)

--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
@@ -155,14 +155,9 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
                stopSimulation(run);
             }
          } else if (msg instanceof AgentReadyMessage) {
-            if (!run.validation) {
-               agent.status = AgentInfo.Status.READY;
-               if (run.agents.stream().allMatch(a -> a.status == AgentInfo.Status.READY)) {
-                  startSimulation(run);
-               }
-            } else { //stop simulation from running if a validation run
-               agent.status = AgentInfo.Status.STOPPED;
-               stopSimulation(run);
+            agent.status = AgentInfo.Status.READY;
+            if (run.agents.stream().allMatch(a -> a.status == AgentInfo.Status.READY)) {
+               startSimulation(run);
             }
          } else {
             log.error("Unexpected type of message: {}", msg);
@@ -212,10 +207,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
                      ControllerPhase controllerPhase = run.phases.get(pscm.phase);
                      if (controllerPhase != null) {
                         tryCompletePhase(run, pscm.phase, controllerPhase);
-                     } else if (!run.validation) {
-                        // if run.validation is true, then startSimulation is not executed and the phases are not
-                        // added in the list, therefore it is expected that the phase is not found
-                        // log the error if and only if the phase is not found, and we are not running just validation
+                     } else {
                         log.error("Run {}: Cannot find phase {}!", run.id, pscm.phase);
                      }
                   }
@@ -500,13 +492,13 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       }
    }
 
-   Run createRun(Benchmark benchmark, String description, Boolean validate) {
+   Run createRun(Benchmark benchmark, String description) {
       ensureMaxInMemoryRuns();
       String runId = String.format("%04X", runIds.getAndIncrement());
       Path runDir = Controller.RUN_DIR.resolve(runId);
       //noinspection ResultOfMethodCallIgnored
       runDir.toFile().mkdirs();
-      Run run = new Run(runId, runDir, benchmark, validate);
+      Run run = new Run(runId, runDir, benchmark);
       run.initStore(new StatisticsStore(benchmark, failure -> log.warn("Failed verify SLA(s) for {}/{}: {}",
             failure.phase(), failure.metric(), failure.message())));
       run.description = description;
@@ -533,7 +525,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
    }
 
    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
-   String startBenchmark(Run run, Boolean validation) {
+   String startBenchmark(Run run) {
       Set<String> activeAgents = new HashSet<>();
       for (Run r : runs.values()) {
          if (!r.terminateTime.future().isComplete()) {

--- a/clustering/src/main/java/io/hyperfoil/clustering/Run.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/Run.java
@@ -32,21 +32,15 @@ class Run {
    boolean completed;
    // set to true once the all.json and related files are persisted in the filesystem
    boolean persisted;
-   boolean validation;
    Supplier<StatisticsStore> statsSupplier;
    private StatisticsStore statisticsStore;
    Map<String, GlobalData.Element> newGlobalData = new HashMap<>();
 
    Run(String id, Path dir, Benchmark benchmark) {
-      this(id, dir, benchmark, false);
-   }
-
-   Run(String id, Path dir, Benchmark benchmark, Boolean validation) {
       this.id = id;
       this.dir = dir;
       this.benchmark = benchmark;
       this.phasesById = benchmark.phasesById();
-      this.validation = validation;
    }
 
    void initStore(StatisticsStore store) {

--- a/controller-api/src/main/resources/openapi.yaml
+++ b/controller-api/src/main/resources/openapi.yaml
@@ -161,11 +161,6 @@ paths:
           type: array
           items:
             type: string
-      - in: query
-        name: validate
-        description: Validate benchmark without running simulation
-        schema:
-          type: boolean
       responses:
         '202':
           description: Run was successfully started.


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Hyperfoil/issues/404

Replace https://github.com/Hyperfoil/Hyperfoil/pull/480

## Changes proposed

This is going to introduce a breaking change in the controller API, specifically for the `startBenchmark` call.

- [x] Remove the validation run logic as not used anymore
- [x] Change the controller server api

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>