### PR TITLE
[0.27.x] Make delayed step to work with nanos

### DIFF
--- a/core/src/main/java/io/hyperfoil/core/impl/PhaseInstanceImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/PhaseInstanceImpl.java
@@ -35,6 +35,7 @@ public abstract class PhaseInstanceImpl implements PhaseInstance {
    private PhaseChangeHandler phaseChangeHandler;
    // Reads are done without locks
    protected volatile Status status = Status.NOT_STARTED;
+   // in milliseconds
    protected long absoluteStartTime;
    protected String absoluteStartTimeString;
    protected AtomicInteger activeSessions = new AtomicInteger(0);

--- a/core/src/main/java/io/hyperfoil/core/steps/AwaitDelayStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/AwaitDelayStep.java
@@ -24,7 +24,8 @@ public class AwaitDelayStep implements Step {
    @Override
    public boolean invoke(Session session) {
       ScheduleDelayStep.Timestamp blockedUntil = (ScheduleDelayStep.Timestamp) key.getObject(session);
-      return System.currentTimeMillis() >= blockedUntil.timestamp;
+      // checking the diff because of the possibility of numerical overflow.
+      return (System.nanoTime() - blockedUntil.timestamp) >= 0;
    }
 
    /**

--- a/core/src/main/java/io/hyperfoil/core/steps/ScheduleDelayStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/ScheduleDelayStep.java
@@ -42,7 +42,7 @@ public class ScheduleDelayStep implements Step, ResourceUtilizer {
    @Override
    public boolean invoke(Session session) {
       Timestamp blockedUntil = (Timestamp) key.activate(session);
-      long now = System.currentTimeMillis();
+      long now = System.nanoTime();
       long baseTimestamp;
       switch (type) {
          case FROM_LAST:
@@ -62,7 +62,7 @@ public class ScheduleDelayStep implements Step, ResourceUtilizer {
       long delay = blockedUntil.timestamp - now;
       if (delay > 0) {
          log.trace("Scheduling #{} to run in {}", session.uniqueId(), delay);
-         session.executor().schedule(session.runTask(), delay, TimeUnit.MILLISECONDS);
+         session.executor().schedule(session.runTask(), delay, TimeUnit.NANOSECONDS);
       } else {
          log.trace("Continuing, duration {} resulted in delay {}", duration, delay);
       }
@@ -126,7 +126,7 @@ public class ScheduleDelayStep implements Step, ResourceUtilizer {
       }
 
       public Builder duration(long duration, TimeUnit timeUnit) {
-         this.duration = timeUnit == null ? 0 : timeUnit.toMillis(duration);
+         this.duration = timeUnit == null ? 0 : timeUnit.toNanos(duration);
          return this;
       }
 
@@ -137,7 +137,7 @@ public class ScheduleDelayStep implements Step, ResourceUtilizer {
        * @return Self.
        */
       public Builder duration(String duration) {
-         this.duration = Util.parseToMillis(duration);
+         this.duration = Util.parseToNanos(duration);
          return this;
       }
 

--- a/docs/site/content/en/docs/user-guide/troubleshooting/index.md
+++ b/docs/site/content/en/docs/user-guide/troubleshooting/index.md
@@ -107,8 +107,6 @@ even if that will never happen because of how the benchmark is configured.
 First of all just check whether the benchmark uses `awaitVar` and if so, double check whether there might be cases
 where that variable the step is waiting for could be NOT set.
 
-Another check
-
 **Can you give me an example?**
 
 Consider a simple use case where you are calling an endpoint and save the result into a variable:

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpResponseHandlersImpl.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpResponseHandlersImpl.java
@@ -574,7 +574,7 @@ public class HttpResponseHandlersImpl implements HttpResponseHandlers, Serializa
                      ReadAccess inputVar = sequenceScopedReadAccess(delayedCoordVar);
                      ObjectAccess delayVar = sequenceScopedObjectAccess(delay);
                      SerializableToLongFunction<Session> delayFunc = session -> TimeUnit.SECONDS
-                           .toMillis(((Redirect.Coords) inputVar.getObject(session)).delay);
+                           .toNanos(((Redirect.Coords) inputVar.getObject(session)).delay);
                      return new ScheduleDelayStep(delayVar, ScheduleDelayStep.Type.FROM_NOW, delayFunc);
                   })
                   .step(() -> new AwaitDelayStep(sequenceScopedReadAccess(delay)))

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/ThinkTimeTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/ThinkTimeTest.java
@@ -1,0 +1,132 @@
+package io.hyperfoil.benchmark.standalone;
+
+import static io.hyperfoil.http.steps.HttpStepCatalog.SC;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.hyperfoil.api.config.Benchmark;
+import io.hyperfoil.api.config.BenchmarkBuilder;
+import io.hyperfoil.api.config.Phase;
+import io.hyperfoil.api.session.PhaseInstance;
+import io.hyperfoil.api.statistics.StatisticsSnapshot;
+import io.hyperfoil.benchmark.BaseBenchmarkTest;
+import io.hyperfoil.core.handlers.TransferSizeRecorder;
+import io.hyperfoil.core.impl.LocalSimulationRunner;
+import io.hyperfoil.core.impl.statistics.StatisticsCollector;
+import io.hyperfoil.core.util.CountDown;
+import io.hyperfoil.http.api.HttpMethod;
+import io.hyperfoil.http.config.HttpPluginBuilder;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+
+@Tag("io.hyperfoil.test.Benchmark")
+public class ThinkTimeTest extends BaseBenchmarkTest {
+   private static final Logger log = LogManager.getLogger(ThinkTimeTest.class);
+   private static final long benchmarkDuration = 1000;
+
+   // parameters source
+   private static Stream<Arguments> thinkTimesConfigs() {
+      return Stream.of(
+            Arguments.of("phase a", 50),
+            Arguments.of("phase b", 500),
+            Arguments.of("phase c", 1000));
+   }
+
+   @Override
+   protected Handler<HttpServerRequest> getRequestHandler() {
+      return req -> {
+         req.response().end("hello from server");
+      };
+   }
+
+   @ParameterizedTest
+   @MethodSource("thinkTimesConfigs")
+   public void testThinkTime(String phase1, long delayMs) {
+      BenchmarkBuilder builder = createBuilder(phase1, delayMs);
+      Benchmark benchmark = builder.build();
+
+      // check think time is correctly setup
+      Phase mainPhase = benchmark.phases().stream().filter(p -> p.name.equals(phase1)).findAny().orElseThrow();
+      // beforeSync, prepareHttpReq, sendHttpReq, afterSync, scheduleDelay, awaitDelay
+      assertEquals(6, mainPhase.scenario().sequences()[0].steps().length);
+
+      TestStatistics statisticsConsumer = new TestStatistics();
+      LocalSimulationRunner runner = new LocalSimulationRunner(benchmark, statisticsConsumer, null, null);
+      runner.run();
+      long now = System.currentTimeMillis();
+
+      // check start time
+      PhaseInstance phase = runner.instances().get(phase1);
+      long expectedDuration = phase.definition().duration();
+      long remaining = expectedDuration - (now - phase.absoluteStartTime());
+      log.debug("Remaining = {}", remaining);
+
+      StatisticsSnapshot stats = statisticsConsumer.stats().get("request");
+      assertEquals(0, stats.invalid);
+      // the thinkTime starts just after the request is completed
+      assertTrue(remaining < 0);
+   }
+
+   /**
+    * create a builder with two phases where the first one should start with the second one after a provided delay
+    */
+   private BenchmarkBuilder createBuilder(String firstPhase, long thinkTime) {
+      // @formatter:off
+      BenchmarkBuilder builder = BenchmarkBuilder.builder()
+            .name("thinkTime " + new SimpleDateFormat("yy/MM/dd HH:mm:ss").format(new Date()))
+            .addPlugin(HttpPluginBuilder::new).http()
+            .host("localhost").port(httpServer.actualPort())
+            .sharedConnections(50)
+            .endHttp().endPlugin()
+            .threads(1);
+
+      builder.addPhase(firstPhase).constantRate(50)
+            .duration(benchmarkDuration)
+            .maxSessions(50)
+            .scenario()
+               .initialSequence("request")
+                  .step(SC).httpRequest(HttpMethod.GET)
+                     .path("/")
+                     .timeout("60s")
+                     .handler()
+                        .rawBytes(new TransferSizeRecorder("transfer"))
+                     .endHandler()
+                  .endStep()
+                  .step(SC)
+                     .thinkTime(thinkTime, TimeUnit.MILLISECONDS)
+                  .endStep()
+               .endSequence();
+      // @formatter:on
+
+      return builder;
+   }
+
+   public static class TestStatistics implements StatisticsCollector.StatisticsConsumer {
+      private final Map<String, StatisticsSnapshot> stats = new HashMap<>();
+
+      @Override
+      public void accept(Phase phase, int stepId, String metric, StatisticsSnapshot snapshot, CountDown countDown) {
+         log.debug("Adding stats for {}/{}/{} - #{}: {} requests {} responses", phase, stepId, metric,
+               snapshot.sequenceId, snapshot.requestCount, snapshot.responseCount);
+         stats.computeIfAbsent(metric, n -> new StatisticsSnapshot()).add(snapshot);
+      }
+
+      public Map<String, StatisticsSnapshot> stats() {
+         return stats;
+      }
+   }
+}


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Hyperfoil/pull/531

<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Related to https://github.com/Hyperfoil/Hyperfoil/issues/522

A bit of context, the only reason for which adding `thinkTime` could make Hyperfoil hanging indefinitely is when https://github.com/Hyperfoil/Hyperfoil/blob/ae0cc9937ca9fa3a25ac737d07c99a5c567e407e/core/src/main/java/io/hyperfoil/core/steps/ScheduleDelayStep.java#L65 is properly scheduled after the specified amount of time but for some reason the check at https://github.com/Hyperfoil/Hyperfoil/blob/ae0cc9937ca9fa3a25ac737d07c99a5c567e407e/core/src/main/java/io/hyperfoil/core/steps/AwaitDelayStep.java#L27 returns `false` - this could happen if `System.currentTimeMillis()` returns a value back in time because of some adjustments. Correct me if I am wrong @franz1981. See also this other comment https://github.com/Hyperfoil/Hyperfoil/issues/377#issue-2379044267.

With this PR I am proposing to rely in the `nano` time which should be more reliable

## Changes proposed

- [x] Check delays using nanoTime rather than milliseconds

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>