### PR TITLE
Reduce GC pressure while parsing HTTP headers (Fixes #537)

### DIFF
--- a/http/src/main/java/io/hyperfoil/http/api/HttpResponseHandlers.java
+++ b/http/src/main/java/io/hyperfoil/http/api/HttpResponseHandlers.java
@@ -6,6 +6,8 @@ import io.netty.buffer.ByteBuf;
 public interface HttpResponseHandlers extends ResponseHandlers<HttpRequest> {
    void handleStatus(HttpRequest request, int status, String reason);
 
+   boolean requiresHandlingHeaders(HttpRequest request);
+
    void handleHeader(HttpRequest request, CharSequence header, CharSequence value);
 
    void handleBodyPart(HttpRequest request, ByteBuf data, int offset, int length, boolean isLastPart);

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpResponseHandlersImpl.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpResponseHandlersImpl.java
@@ -86,6 +86,11 @@ public class HttpResponseHandlersImpl implements HttpResponseHandlers, Serializa
    }
 
    @Override
+   public boolean requiresHandlingHeaders(HttpRequest request) {
+      return (headerHandlers != null && headerHandlers.length > 0) || request.hasCacheControl() || trace;
+   }
+
+   @Override
    public void handleStatus(HttpRequest request, int status, String reason) {
       Session session = request.session;
       if (request.isCompleted()) {


### PR DESCRIPTION
It saves handling the headers (parsing and materialize them as proper `AsciiString`/`String`s pairs) - if not required.
This will apply if HTTP caching is disabled (e.g. wrk/wrk2) since HTTP caching requires parsing dates from proper headers (sees #536) - which means that only expert/informed users would benefit of it.

Fixes #537 - although there's still room to reduce the pressure with proper HTTP header names/value caching.