### PR TITLE
Allocation free date parsing

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -33,6 +33,10 @@
             <groupId>io.hyperfoil</groupId>
             <artifactId>hyperfoil-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.hyperfoil</groupId>
+            <artifactId>hyperfoil-http</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/benchmarks/src/main/java/io/hyperfoil/http/ParseDateBenchmark.java
+++ b/benchmarks/src/main/java/io/hyperfoil/http/ParseDateBenchmark.java
@@ -1,0 +1,39 @@
+package io.hyperfoil.http;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public class ParseDateBenchmark {
+
+   private String[] sequences;
+
+   @Setup
+   public void setup() {
+      sequences = new String[] { "Tue, 29 Oct 2024 16:56:32 UTC", "Tue, 29 Oct 2024 16:56:32 GMT",
+            "Tue, 29 Oct 2024 16:56:32 CET" };
+   }
+
+   @Benchmark
+   public void parseDates(Blackhole bh) {
+      for (String seq : sequences) {
+         bh.consume(HttpUtil.parseDate(seq));
+      }
+   }
+}

--- a/http/src/test/java/io/hyperfoil/http/HttpCacheTest.java
+++ b/http/src/test/java/io/hyperfoil/http/HttpCacheTest.java
@@ -111,13 +111,13 @@ public class HttpCacheTest extends VertxBaseTest {
       context.serverQueue.add(req -> req.response()
             .putHeader(HttpHeaderNames.EXPIRES, HttpUtil.formatDate(CLOCK.instant().plusSeconds(5).toEpochMilli())).end());
       context.handlers.add(req -> {
-         assertEquals(context.serverRequests.get(), 1);
+         assertEquals(1, context.serverRequests.get());
          assertCacheHits(ctx, req, 0);
       });
 
       context.requests.add(() -> doRequest(context, GET_TEST, null));
       context.handlers.add(req -> {
-         assertEquals(context.serverRequests.get(), 1);
+         assertEquals(1, context.serverRequests.get());
          assertCacheHits(ctx, req, 1);
          CLOCK.advance(6000);
       });
@@ -125,15 +125,15 @@ public class HttpCacheTest extends VertxBaseTest {
       context.requests.add(() -> doRequest(context, GET_TEST, null));
       context.serverQueue.add(req -> req.response().end());
       context.handlers.add(req -> {
-         assertEquals(context.serverRequests.get(), 2);
+         assertEquals(2, context.serverRequests.get());
          assertCacheHits(ctx, req, 0);
       });
 
       context.requests.add(
             () -> doRequest(context, GET_TEST, (s, writer) -> writer.putHeader(HttpHeaderNames.CACHE_CONTROL, "max-stale=10")));
       context.handlers.add(req -> {
-         assertEquals(context.serverRequests.get(), 2);
-         assertEquals(HttpCache.get(context.session).size(), 1);
+         assertEquals(2, context.serverRequests.get());
+         assertEquals(1, HttpCache.get(context.session).size());
          assertTrue(context.serverQueue.isEmpty());
          assertCacheHits(ctx, req, 1);
          checkpoint.flag();


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes https://github.com/Hyperfoil/Hyperfoil/issues/536

## Changes proposed

Create a static map in `FastThreadLocal` with the most common TZ Calendars (i.e., `UTC` and `GMT`) so that we don't need to allocate such Calendars object in the hot path (i.e., when parsing the dates)

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>