### PR TITLE
Stop using a Session if the delay is already expired

### DIFF
--- a/core/src/main/java/io/hyperfoil/core/steps/ScheduleDelayStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/ScheduleDelayStep.java
@@ -3,6 +3,7 @@ package io.hyperfoil.core.steps;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -62,7 +63,7 @@ public class ScheduleDelayStep implements Step, ResourceUtilizer {
       long delay = blockedUntil.timestamp - now;
       if (delay > 0) {
          log.trace("Scheduling #{} to run in {}", session.uniqueId(), delay);
-         session.executor().schedule(session.runTask(), delay, TimeUnit.NANOSECONDS);
+         blockedUntil.delayExpired = session.executor().schedule(session.runTask(), delay, TimeUnit.NANOSECONDS);
       } else {
          log.trace("Continuing, duration {} resulted in delay {}", duration, delay);
       }
@@ -97,6 +98,7 @@ public class ScheduleDelayStep implements Step, ResourceUtilizer {
 
    static class Timestamp {
       long timestamp = Long.MAX_VALUE;
+      ScheduledFuture<?> delayExpired;
    }
 
    /**

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/ThinkTimeTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/ThinkTimeTest.java
@@ -41,9 +41,10 @@ public class ThinkTimeTest extends BaseBenchmarkTest {
    // parameters source
    private static Stream<Arguments> thinkTimesConfigs() {
       return Stream.of(
-            Arguments.of("phase a", 50),
-            Arguments.of("phase b", 500),
-            Arguments.of("phase c", 1000));
+            Arguments.of("phase a", 1),
+            Arguments.of("phase a", TimeUnit.MILLISECONDS.toNanos(50)),
+            Arguments.of("phase b", TimeUnit.MILLISECONDS.toNanos(500)),
+            Arguments.of("phase c", TimeUnit.MILLISECONDS.toNanos(1000)));
    }
 
    @Override
@@ -55,8 +56,8 @@ public class ThinkTimeTest extends BaseBenchmarkTest {
 
    @ParameterizedTest
    @MethodSource("thinkTimesConfigs")
-   public void testThinkTime(String phase1, long delayMs) {
-      BenchmarkBuilder builder = createBuilder(phase1, delayMs);
+   public void testThinkTime(String phase1, long delayNs) {
+      BenchmarkBuilder builder = createBuilder(phase1, delayNs);
       Benchmark benchmark = builder.build();
 
       // check think time is correctly setup
@@ -107,7 +108,7 @@ public class ThinkTimeTest extends BaseBenchmarkTest {
                      .endHandler()
                   .endStep()
                   .step(SC)
-                     .thinkTime(thinkTime, TimeUnit.MILLISECONDS)
+                     .thinkTime(thinkTime, TimeUnit.NANOSECONDS)
                   .endStep()
                .endSequence();
       // @formatter:on


### PR DESCRIPTION
## Changes proposed

Currently, due to lack of cpu resources (e.g. on containers, GC, etc etc) a short delay can cause a scheduled task to use a Session which it doesn't "own" anymore, because released after executing the sequence it belongs.
This is happening because:
- `ScheduleDelayStep::invoke` schedule a short living scheduled task
- `AwaitDelayStep` is always executed after `ScheduleDelayStep`, and due to many reasons, can find the delay to be already expired
- `Session`s completes and got used elsewhere
- the short living scheduled task executes `Session::runTask`  on a `Session` which doesn't "own" anymore

We're not aware of any adverse effect of using a `Session` which we don't own - since `Session`s are single-threaded, at worse it can run some stucked `step` once more, while making it to progress earlier than expected, which means that it depends by the nature of the step to be executed.

## Check List

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
