### PR TITLE
JsonParser handler broken when the response is fragmented (Fixes #533)

### DIFF
--- a/core/src/main/java/io/hyperfoil/core/handlers/json/ByteArrayByteStream.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/json/ByteArrayByteStream.java
@@ -1,0 +1,59 @@
+package io.hyperfoil.core.handlers.json;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class ByteArrayByteStream implements ByteStream {
+   private final Function<ByteStream, ByteStream> retain;
+   private final Consumer<ByteStream> release;
+   private byte[] array;
+   private int readerIndex;
+
+   public ByteArrayByteStream(Function<ByteStream, ByteStream> retain, Consumer<ByteStream> release) {
+      this.retain = retain;
+      this.release = release;
+   }
+
+   public byte[] array() {
+      return array;
+   }
+
+   @Override
+   public int getByte(int index) {
+      return array[index];
+   }
+
+   @Override
+   public int writerIndex() {
+      return array.length;
+   }
+
+   @Override
+   public int readerIndex() {
+      return readerIndex;
+   }
+
+   @Override
+   public void release() {
+      release.accept(this);
+   }
+
+   @Override
+   public ByteStream retain() {
+      return retain.apply(this);
+   }
+
+   @Override
+   public void moveTo(ByteStream other) {
+      ByteArrayByteStream o = (ByteArrayByteStream) other;
+      o.array = array;
+      o.readerIndex = readerIndex;
+      array = null;
+   }
+
+   public ByteArrayByteStream wrap(byte[] array) {
+      this.array = array;
+      this.readerIndex = 0;
+      return this;
+   }
+}

--- a/core/src/main/java/io/hyperfoil/core/handlers/json/ByteBufByteStream.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/json/ByteBufByteStream.java
@@ -1,0 +1,69 @@
+package io.hyperfoil.core.handlers.json;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import io.netty.buffer.ByteBuf;
+
+public class ByteBufByteStream implements ByteStream {
+   private final Function<ByteStream, ByteStream> retain;
+   private final Consumer<ByteStream> release;
+   private ByteBuf buffer;
+   private int readerIndex, writerIndex;
+
+   public ByteBufByteStream(Function<ByteStream, ByteStream> retain, Consumer<ByteStream> release) {
+      this.retain = retain;
+      this.release = release;
+   }
+
+   @Override
+   public int getByte(int index) {
+      return buffer.getByte(index);
+   }
+
+   @Override
+   public int writerIndex() {
+      return writerIndex;
+   }
+
+   @Override
+   public int readerIndex() {
+      return readerIndex;
+   }
+
+   @Override
+   public void release() {
+      buffer.release();
+      buffer = null;
+      readerIndex = -1;
+      release.accept(this);
+   }
+
+   @Override
+   public ByteStream retain() {
+      buffer.retain();
+      return retain.apply(this);
+   }
+
+   @Override
+   public void moveTo(ByteStream other) {
+      ByteBufByteStream o = (ByteBufByteStream) other;
+      assert o.buffer == null;
+      o.buffer = buffer;
+      o.readerIndex = readerIndex;
+      o.writerIndex = writerIndex;
+      buffer = null;
+      readerIndex = -1;
+   }
+
+   public ByteBuf buffer() {
+      return buffer;
+   }
+
+   public ByteBufByteStream wrap(ByteBuf data, int readerIndex, int writerIndex) {
+      this.buffer = data;
+      this.readerIndex = readerIndex;
+      this.writerIndex = writerIndex;
+      return this;
+   }
+}

--- a/core/src/main/java/io/hyperfoil/core/handlers/json/StreamQueue.java
+++ b/core/src/main/java/io/hyperfoil/core/handlers/json/StreamQueue.java
@@ -3,120 +3,259 @@ package io.hyperfoil.core.handlers.json;
 import java.io.Serializable;
 import java.util.Arrays;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.jctools.util.Pow2;
 
 /**
  * This serves as an abstraction over several {@link ByteStream bytestreams} so that users can just append
  * new buffers to the back and use absolute positioning with single index.
  */
 public class StreamQueue {
-   protected static final Logger log = LogManager.getLogger(StreamQueue.class);
-
-   private final ByteStream[] parts;
+   private ByteStream[] parts;
    // indices used by users for the beginning (readerIndex) of the bytestream
-   private final int[] userIndex;
-   private final int mask;
+   private int[] userIndex;
+   private int mask;
    private int end = -1;
-   private int tail = 0;
    private int length = 0;
 
-   public StreamQueue(int capacity) {
-      this.mask = (1 << 32 - Integer.numberOfLeadingZeros(capacity - 1)) - 1;
-      this.parts = new ByteStream[capacity];
-      this.userIndex = new int[capacity];
+   public StreamQueue(int initialCapacity) {
+      initialCapacity = Pow2.roundToPowerOfTwo(initialCapacity);
+      this.mask = initialCapacity - 1;
+      this.parts = new ByteStream[initialCapacity];
+      this.userIndex = new int[initialCapacity];
       Arrays.fill(userIndex, -1);
    }
 
+   /**
+    * WARNING: use this only for testing!
+    */
+   int firstAvailableIndex() {
+      return totalAppendedBytes() - bytes();
+   }
+
+   /**
+    * WARNING: use this only for testing!
+    */
+   int bytes() {
+      int bytes = 0;
+      for (ByteStream part : this.parts) {
+         if (part != null) {
+            bytes += readableBytesOf(part);
+         }
+      }
+      return bytes;
+   }
+
+   /**
+    * WARNING: use this only for testing!
+    */
+   int availableCapacityBeforeEnlargement() {
+      // how many nulls from end to tail?
+      if (end == -1) {
+         return parts.length;
+      } else {
+         // how many nulls, including the tail we have till wrapping back to end?
+         int next = next(end);
+         int contiguousNulls = 0;
+         for (int i = 0; i < parts.length; i++) {
+            if (parts[next] != null) {
+               break;
+            }
+            next = next(next);
+            contiguousNulls++;
+         }
+         return contiguousNulls;
+      }
+   }
+
+   /**
+    * WARNING: use this only for testing!
+    */
+   int parts() {
+      int count = 0;
+      for (ByteStream part : this.parts) {
+         if (part != null) {
+            count++;
+         }
+      }
+      return count;
+   }
+
+   private int totalAppendedBytes() {
+      return length;
+   }
+
+   public int enlargeCapacity(int tail) {
+      assert parts[tail] != null;
+      int newCapacity = Pow2.roundToPowerOfTwo(mask + 2);
+      ByteStream[] newParts = new ByteStream[newCapacity];
+      int[] newUserIndex = new int[newCapacity];
+      int secondHalfToCopy = parts.length - tail;
+      System.arraycopy(parts, tail, newParts, 0, secondHalfToCopy);
+      System.arraycopy(userIndex, tail, newUserIndex, 0, secondHalfToCopy);
+      if (tail > 0) {
+         // copy the first part only if needed
+         System.arraycopy(parts, 0, newParts, secondHalfToCopy, tail);
+         System.arraycopy(userIndex, 0, newUserIndex, secondHalfToCopy, tail);
+      }
+      // fill the rest with -1
+      Arrays.fill(newUserIndex, userIndex.length, newCapacity, -1);
+      mask = newCapacity - 1;
+      end = parts.length - 1;
+      tail = parts.length;
+      userIndex = newUserIndex;
+      // help GC
+      Arrays.fill(parts, null);
+      parts = newParts;
+      assert parts[tail] == null;
+      return tail;
+   }
+
    public int append(ByteStream stream) {
+      int tail = next(end);
       if (parts[tail] != null) {
-         log.warn("Too many buffered fragments, dropping data.");
-         parts[tail].release();
+         // enlarging capacity can modify end - we need an updated tail
+         tail = enlargeCapacity(tail);
       }
       ByteStream retained = stream.retain();
       parts[tail] = retained;
-      userIndex[tail] = length;
-      length += retained.writerIndex() - retained.readerIndex();
+      int newUserIndex = length;
+      userIndex[tail] = newUserIndex;
+      length += readableBytesOf(retained);
       end = tail;
-      tail = (tail + 1) & mask;
-      return userIndex[end];
+      return newUserIndex;
    }
 
-   public void release(int index) {
-      int i = end;
-      while (index < userIndex[i]) {
-         i = (i + mask) & mask;
-         if (i == end || parts[i] == null) {
-            return;
-         }
-      }
-      i = (i + mask) & mask;
-      if (i == end || parts[i] == null) {
+   public void releaseUntil(int index) {
+      int i = findPartIndexWith(index);
+      if (i < 0) {
          return;
       }
-      while (i != end && parts[i] != null) {
-         userIndex[i] = -1;
-         parts[i].release();
-         parts[i] = null;
-         i = (i + mask) & mask;
+      assert end >= 0;
+      // Even if index is the last byte accessible within parts[i] we cannot release it too :"(
+      // but we can release the rest
+      i = prev(i);
+      while (hasMoreParts(i)) {
+         releasePart(i);
+         i = prev(i);
       }
    }
 
    public int getByte(int index) {
+      int i = findPartIndexWith(index);
+      if (i < 0) {
+         return -1;
+      }
+      ByteStream part = parts[i];
+      int partIndex = partOffset(index, i);
+      if (partIndex >= readableBytesOf(part)) {
+         return -1;
+      }
+      return part.getByte(readerIndexOf(part, partIndex));
+   }
+
+   /**
+    * Since parts are ordered based on the starting index they deal with, this search backward from the last appended
+    * one - which contains the highest indexes - to find the part which contains the given index.
+    */
+   private int findPartIndexWith(int index) {
+      if (index < 0) {
+         return -1;
+      }
       int i = end;
+      if (i < 0) {
+         return -1;
+      }
       while (index < userIndex[i]) {
-         i = (i + mask) & mask;
-         if (i == end || parts[i] == null) {
-            //            throw new IndexOutOfBoundsException("Underflowing the queue with index " + index);
+         i = prev(i);
+         if (!hasMoreParts(i)) {
             return -1;
          }
       }
-      ByteStream part = parts[i];
-      int partIndex = index - userIndex[i];
-      if (part.readerIndex() + partIndex >= part.writerIndex()) {
-         return -1;
-      }
-      return part.getByte(part.readerIndex() + partIndex);
+      return i;
    }
 
    public void reset() {
-      for (int i = 0; i < parts.length; ++i) {
-         if (parts[i] != null) {
-            parts[i].release();
-            parts[i] = null;
-         }
-         userIndex[i] = -1;
+      if (end >= 0) {
+         int i = end;
+         do {
+            releasePart(i);
+            i = prev(i);
+         } while (hasMoreParts(i));
+         end = -1;
       }
       length = 0;
-      end = -1;
    }
 
    public <P1, P2> void consume(int startIndex, int endIndex, Consumer<P1, P2> consumer, P1 p1, P2 p2, boolean isComplete) {
-      int i = end;
-      while (startIndex < userIndex[i]) {
-         i = (i + mask) & mask;
-         if (i == end || parts[i] == null) {
-            //            throw new IndexOutOfBoundsException("Underflowing the queue with index " + index);
-            ++i;
-            break;
-         }
+      validateIndexes(startIndex, endIndex);
+      if (startIndex == endIndex) {
+         return;
       }
-      int partIndex = startIndex - userIndex[i];
+      int i = findPartIndexWith(startIndex);
+      if (i < 0) {
+         throw new IllegalArgumentException("Start index " + startIndex + " not found.");
+      }
+      int partStartIndex = partOffset(startIndex, i);
       boolean isLast = false;
       while (!isLast) {
          ByteStream part = parts[i];
-         int end = part.writerIndex();
-         if (endIndex <= userIndex[i] + part.writerIndex() - part.readerIndex()) {
-            end = endIndex - userIndex[i] + part.readerIndex();
-            isLast = true;
+         final int readableBytes = readableBytesOf(part);
+         final int partEndIndex = partOffset(endIndex, i);
+         isLast = partEndIndex <= readableBytes;
+         final int length;
+         if (isLast) {
+            length = partEndIndex - partStartIndex;
+         } else {
+            length = readableBytes - partStartIndex;
          }
-         int length = end - partIndex - part.readerIndex();
          if (length > 0) {
-            consumer.accept(p1, p2, part, part.readerIndex() + partIndex, length, isComplete && isLast);
+            consumer.accept(p1, p2, part, readerIndexOf(part, partStartIndex), length, isComplete && isLast);
          }
-         partIndex = 0;
-         i = (i + 1) & mask;
+         partStartIndex = 0;
+         i = next(i);
       }
+   }
+
+   private static int readableBytesOf(ByteStream stream) {
+      return stream.writerIndex() - stream.readerIndex();
+   }
+
+   private static int readerIndexOf(ByteStream part, int partIndex) {
+      return part.readerIndex() + partIndex;
+   }
+
+   private int partOffset(int streamIndex, int part) {
+      return streamIndex - userIndex[part];
+   }
+
+   private void validateIndexes(int startIndex, int endIndex) {
+      if (startIndex < 0 || endIndex < 0) {
+         throw new IllegalArgumentException("Start and end indexes must be non-negative.");
+      }
+      if (startIndex >= length || endIndex > length) {
+         throw new IllegalArgumentException("Start and end indexes must be within the bounds of the stream.");
+      }
+      if (startIndex > endIndex) {
+         throw new IllegalArgumentException("Start index must be less than end index.");
+      }
+   }
+
+   private int prev(int i) {
+      return (i - 1) & mask;
+   }
+
+   private int next(int i) {
+      return (i + 1) & mask;
+   }
+
+   private boolean hasMoreParts(int i) {
+      return i != end && userIndex[i] != -1;
+   }
+
+   private void releasePart(int i) {
+      userIndex[i] = -1;
+      parts[i].release();
+      parts[i] = null;
    }
 
    public interface Consumer<P1, P2> extends Serializable {

--- a/core/src/test/java/io/hyperfoil/core/handlers/json/StreamQueueTest.java
+++ b/core/src/test/java/io/hyperfoil/core/handlers/json/StreamQueueTest.java
@@ -1,0 +1,248 @@
+package io.hyperfoil.core.handlers.json;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.netty.buffer.Unpooled;
+
+public class StreamQueueTest {
+
+   private static final int DATA_SIZE = 10;
+   private static IdentityHashMap<ByteStream, AtomicInteger> releaseCounters = new IdentityHashMap<>();
+   private static IdentityHashMap<ByteStream, AtomicInteger> retainCounters = new IdentityHashMap<>();
+   private static int generatedDataBytes;
+   private static List<byte[]> generatedData = new ArrayList<>();
+
+   @AfterEach
+   public void tearDown() {
+      releaseCounters.clear();
+      retainCounters.clear();
+      generatedDataBytes = 0;
+      generatedData.clear();
+   }
+
+   private static ByteStream trackRetain(ByteStream stream) {
+      retainCounters.computeIfAbsent(stream, s -> new AtomicInteger()).incrementAndGet();
+      return stream;
+   }
+
+   private static void trackReleaseUntil(ByteStream stream) {
+      releaseCounters.computeIfAbsent(stream, s -> new AtomicInteger()).incrementAndGet();
+   }
+
+   /**
+    * WARNING: this assumes that data generation and order by which data is appended is the same!
+    */
+   private static byte[] generateData(int length) {
+      byte[] array = new byte[length];
+      int value = generatedDataBytes;
+      for (int i = 0; i < length; ++i) {
+         int nextValue = value + i;
+         byte positiveValue = (byte) (nextValue & 0x7F);
+         assert positiveValue >= 0;
+         array[i] = positiveValue;
+      }
+      generatedDataBytes += length;
+      generatedData.add(array);
+      return array;
+   }
+
+   private static byte[] dumpGeneratedData() {
+      byte[] allData = new byte[generatedDataBytes];
+      int written = 0;
+      for (byte[] array : generatedData) {
+         System.arraycopy(array, 0, allData, written, array.length);
+         written += array.length;
+      }
+      return allData;
+   }
+
+   private static void removeFirstGeneratedData() {
+      if (generatedData.isEmpty()) {
+         return;
+      }
+      var data = generatedData.remove(0);
+      generatedDataBytes -= data.length;
+   }
+
+   private static void removeLastGeneratedData() {
+      if (generatedData.isEmpty()) {
+         return;
+      }
+      var lastData = generatedData.remove(generatedData.size() - 1);
+      generatedDataBytes -= lastData.length;
+   }
+
+   static Supplier<ByteStream>[] byteStreamProvider() {
+      Function<ByteStream, ByteStream> retain = StreamQueueTest::trackRetain;
+      Consumer<ByteStream> release = StreamQueueTest::trackReleaseUntil;
+      return new Supplier[] {
+            () -> new ByteBufByteStream(retain, release).wrap(Unpooled.wrappedBuffer(generateData(DATA_SIZE)), 0, 10),
+            () -> new ByteArrayByteStream(retain, release).wrap(generateData(DATA_SIZE))
+      };
+   }
+
+   private static void assertRetain(ByteStream stream, int expectedCount) {
+      assertCount(stream, expectedCount, retainCounters);
+   }
+
+   private static void assertRelease(ByteStream stream, int expectedCount) {
+      assertCount(stream, expectedCount, releaseCounters);
+   }
+
+   private static void assertCount(ByteStream stream, int expectedCount, Map<ByteStream, AtomicInteger> countMap) {
+      var counter = countMap.get(stream);
+      if (expectedCount == 0) {
+         assertNull(counter);
+      } else {
+         assertNotNull(counter);
+         assertEquals(expectedCount, counter.get());
+      }
+   }
+
+   private static byte[] streamDataOf(StreamQueue streamQueue) {
+      byte[] streamData = new byte[streamQueue.bytes()];
+      int offset = streamQueue.firstAvailableIndex();
+      for (int i = 0; i < streamData.length; ++i) {
+         streamData[i] = (byte) streamQueue.getByte(offset);
+         offset++;
+      }
+      return streamData;
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void appendShouldRetainStream(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(1);
+      ByteStream stream = streamFactory.get();
+      assertRetain(stream, 0);
+      streamQueue.append(stream);
+      assertRetain(stream, 1);
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void appendShouldContainsTheOriginalData(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(1);
+      ByteStream stream = streamFactory.get();
+      assertRetain(stream, 0);
+      streamQueue.append(stream);
+      assertRetain(stream, 1);
+      assertEquals(1, streamQueue.parts());
+      assertEquals(DATA_SIZE, streamQueue.bytes());
+      assertArrayEquals(dumpGeneratedData(), streamDataOf(streamQueue));
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void appendWithEnlargementShouldContainsTheOriginalData(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(1);
+      assertEquals(1, streamQueue.availableCapacityBeforeEnlargement());
+      streamQueue.append(streamFactory.get());
+      assertEquals(0, streamQueue.availableCapacityBeforeEnlargement());
+      streamQueue.append(streamFactory.get());
+      assertEquals(0, streamQueue.availableCapacityBeforeEnlargement());
+      assertEquals(2, streamQueue.parts());
+      assertEquals(DATA_SIZE * 2, streamQueue.bytes());
+      assertArrayEquals(dumpGeneratedData(), streamDataOf(streamQueue));
+      streamQueue.append(streamFactory.get());
+      assertEquals(1, streamQueue.availableCapacityBeforeEnlargement());
+      assertEquals(3, streamQueue.parts());
+      assertEquals(DATA_SIZE * 3, streamQueue.bytes());
+      assertArrayEquals(dumpGeneratedData(), streamDataOf(streamQueue));
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void appendAndRemoveWithEnlargementShouldContainsTheRightData(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(1);
+      streamQueue.append(streamFactory.get());
+      streamQueue.append(streamFactory.get());
+      assertEquals(0, streamQueue.availableCapacityBeforeEnlargement());
+      streamQueue.releaseUntil(DATA_SIZE);
+      assertEquals(1, streamQueue.availableCapacityBeforeEnlargement());
+      removeFirstGeneratedData();
+      streamQueue.append(streamFactory.get());
+      assertEquals(0, streamQueue.availableCapacityBeforeEnlargement());
+      assertArrayEquals(dumpGeneratedData(), streamDataOf(streamQueue));
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void removeIfEmptyShouldNotThrowErrors(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(1);
+      streamQueue.releaseUntil(1);
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void removeBeyondExistingIndexesShouldNotRemoveLastAppended(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(2);
+      var firstPart = streamFactory.get();
+      streamQueue.append(firstPart);
+      var secondPart = streamFactory.get();
+      streamQueue.append(secondPart);
+      int beyondLastIndex = streamQueue.bytes();
+      assertEquals(-1, streamQueue.getByte(beyondLastIndex));
+      streamQueue.releaseUntil(3 * DATA_SIZE);
+      assertRelease(firstPart, 1);
+      assertRelease(secondPart, 0);
+      assertEquals(1, streamQueue.parts());
+      removeFirstGeneratedData();
+      assertArrayEquals(dumpGeneratedData(), streamDataOf(streamQueue));
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void removeLastByteOfPartShouldNotRemoveIt(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(2);
+      var firstPart = streamFactory.get();
+      streamQueue.append(firstPart);
+      var secondPart = streamFactory.get();
+      streamQueue.append(secondPart);
+      streamQueue.releaseUntil(2 * DATA_SIZE);
+      assertRelease(firstPart, 1);
+      assertRelease(secondPart, 0);
+      assertEquals(1, streamQueue.parts());
+      removeFirstGeneratedData();
+      assertArrayEquals(dumpGeneratedData(), streamDataOf(streamQueue));
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void appendShouldReturnTheFirstIndexOfEachPart(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(2);
+      var part = streamFactory.get();
+      int index = streamQueue.append(part);
+      assertEquals(0, index);
+      index = streamQueue.append(streamFactory.get());
+      assertEquals(index, DATA_SIZE);
+   }
+
+   @ParameterizedTest
+   @MethodSource("byteStreamProvider")
+   public void resetShouldReleaseAllPartsAndResetLength(Supplier<ByteStream> streamFactory) {
+      var streamQueue = new StreamQueue(2);
+      final var part = streamFactory.get();
+      streamQueue.append(part);
+      streamQueue.reset();
+      assertArrayEquals(new byte[0], streamDataOf(streamQueue));
+      assertRelease(part, 1);
+      assertEquals(0, streamQueue.append(streamFactory.get()));
+   }
+}


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes #533 

## Changes proposed

It is allowing to enlarge both the StreamQueue and the pool which holds `BytesStream`.
Additionally it is simplifying and commenting some code, reusing it, to improve readability and make it less error prone.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] All new and existing tests passed.
- [x] `StreamQueue::consume` is still uncovered by tests (TODO) 