### PR TITLE
Handle SSL handshake timeout

### DIFF
--- a/http/src/main/java/io/hyperfoil/http/connection/HttpChannelInitializer.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/HttpChannelInitializer.java
@@ -71,6 +71,11 @@ class HttpChannelInitializer extends ChannelInitializer<Channel> {
          }
          long sslHandshakeTimeout = clientPool.config().sslHandshakeTimeout();
          sslHandler.setHandshakeTimeoutMillis(sslHandshakeTimeout < 0 ? 0 : sslHandshakeTimeout);
+         sslHandler.handshakeFuture().addListener(future -> {
+            if (!future.isSuccess()) {
+               handler.accept(null, new IOException("SSL handshake failure", future.cause()));
+            }
+         });
          pipeline.addLast(sslHandler);
          pipeline.addLast(alpnHandler);
          if (logMasterKey) {
@@ -108,4 +113,5 @@ class HttpChannelInitializer extends ChannelInitializer<Channel> {
       }
       pipeline.addLast("handler", connection);
    }
+
 }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

While testing https://github.com/Hyperfoil/Hyperfoil/pull/556 I noticed that if we hit the SSL handshake timeout, Hyperfoil hangs indefinitely.

You could reproduce the issue by simply setting the new `sslHandshakeTimeout` to some small amount like `1ms` and use a very simple benchmark:
```
name: tls
threads: 1
http:
  host: https://localhost:8443
  sharedConnections: 1
  sslHandshakeTimeout: 1ms
phases:
- main:
    constantRate:
      usersPerSec: 1
      duration: 10s
      scenario:
      - test:
        - httpRequest:
            GET: /hello
```

You will see that the connection is not established but Hyperfoil keeps hanging without proceeding at all.

I investigated a little bit and it looks like we are not properly handling the SSL handshake timeout on our side (TBH I am not sure whether there is something wrong in the netty configuration)

## Changes proposed

Proposing to add an additional handler checking the handshakeFuture result and if of type `SslHandshakeTimeoutException` handle that as not able to create the connection so that Hyperfoil will properly log the error and stop the run:

```
18:02:51,456 WARN  (epollEventLoopGroup-2-1) [i.h.h.c.SharedConnectionPool] Cannot create connection to localhost:8443 (created: 0, failures: 101) java.io.IOException: SSL handshake timed out
	at io.hyperfoil.http.connection.HttpChannelInitializer.lambda$initChannel$0(HttpChannelInitializer.java:77)
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners0(DefaultPromise.java:583)
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:559)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492)
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636)
	at io.netty.util.concurrent.DefaultPromise.setFailure0(DefaultPromise.java:629)
	at io.netty.util.concurrent.DefaultPromise.tryFailure(DefaultPromise.java:118)
	at io.netty.handler.ssl.SslHandler$8.run(SslHandler.java:2280)
	at io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
	at io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:156)
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:408)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: io.netty.handler.ssl.SslHandshakeTimeoutException: handshake timed out after 10ms
	at io.netty.handler.ssl.SslHandler$8.run(SslHandler.java:2277)
	... 10 more

```

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>