### PR TITLE
Disable HTTP cache by default to save memory

### DIFF
--- a/docs/site/content/en/docs/user-guide/benchmark/http.md
+++ b/docs/site/content/en/docs/user-guide/benchmark/http.md
@@ -28,25 +28,25 @@ http:
 
 HTTP configuration has these properties:
 
-| Property          | Default | Description |
-| ----------------- | ------- | ----------- |
-| protocol          |         | Either `http` or `https` |
-| host              |         | Hostname of the server. For convenience you can use the `http[s]://host[:port]` inline syntax as shown above |
-| port              | `80`&nbsp;or&nbsp;`443` | Default is based on the `protocol` |
-| [sharedConnections](#shared-connections) | 1       | Number of connections to open. It is recommended to set this property to a non-default value. |
-| [connectionStrategy](#connection-strategies) | SHARED_POOL | Connection pooling model (see details below) |
-| addresses         |         | Supply list of IPs or IP:port targets that will be used for the connections instead of resolving the `host` in DNS and using `port` as set - `host` and `port` will be used only for `Host` headers and SNI. If this list contains more addresses the connections will be split evenly. |
-| requestTimeout    | 30 seconds | Default request timeout, this can be overridden in each `httpRequest`. |
-| sslHandshakeTimeout | 10 seconds | SSL handshake timeout |
-| allowHttp1x       | true    | Allow HTTP 1.1 for connections (e.g. during ALPN). |
-| allowHttp2x       | true    | Allow HTTP 2.0 for connections (e.g. during ALPN). If both 1.1 and 2.0 are allowed and `https` is not used (which would trigger ALPN) Hyperfoil will use HTTP 1.1. If only 2.0 is allowed Hyperfoil will start with HTTP 1.1 and perform protocol upgrade to 2.0. |
-| directHttp2       | false   | Start with H2C HTTP 2.0 without protocol upgrade. Makes sense only for plain text (`http`) connections. Currently not implemented. |
-| maxHttp2Streams   | 100     | Maximum number of requests concurrently enqueued on single HTTP 2.0 connection. |
-| pipeliningLimit   | 1       | Maximum number of requests pipelined on single HTTP 1.1 connection. |
-| rawBytesHandlers  | true    | Enable or disable using handlers that process HTTP response raw bytes. |
-| [keyManager](#keymanager-configuration) |         | TLS key manager for setting up client certificates. |
-| [trustManager](#trustmanager-configuration) |         | TLS trust manager for setting up server certificates. |
-| useHttpCache      | true    | Make use of HTTP cache on client-side. If multiple authorities are involved, disable the HTTP cache for all of them to achieve the desired outcomes. The default is `true` except for wrk/wrk2 wrappers where it is set to `false`. |
+| Property         | Default                 | Description                                                                                                                                                                                                                                                                            |
+| ---------------- |-------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| protocol         |                         | Either `http` or `https`                                                                                                                                                                                                                                                               |
+| host             |                         | Hostname of the server. For convenience you can use the `http[s]://host[:port]` inline syntax as shown above                                                                                                                                                                           |
+| port             | `80`&nbsp;or&nbsp;`443` | Default is based on the `protocol`                                                                                                                                                                                                                                                     |
+| [sharedConnections](#shared-connections) | 1                       | Number of connections to open. It is recommended to set this property to a non-default value.                                                                                                                                                                                          |
+| [connectionStrategy](#connection-strategies) | SHARED_POOL             | Connection pooling model (see details below)                                                                                                                                                                                                                                           |
+| addresses        |                         | Supply list of IPs or IP:port targets that will be used for the connections instead of resolving the `host` in DNS and using `port` as set - `host` and `port` will be used only for `Host` headers and SNI. If this list contains more addresses the connections will be split evenly. |
+| requestTimeout   | 30 seconds              | Default request timeout, this can be overridden in each `httpRequest`.                                                                                                                                                                                                                 |
+| sslHandshakeTimeout | 10 seconds              | SSL handshake timeout                                                                                                                                                                                                                                                                  |
+| allowHttp1x      | true                    | Allow HTTP 1.1 for connections (e.g. during ALPN).                                                                                                                                                                                                                                     |
+| allowHttp2       | true                    | Allow HTTP 2.0 for connections (e.g. during ALPN). If both 1.1 and 2.0 are allowed and `https` is not used (which would trigger ALPN) Hyperfoil will use HTTP 1.1. If only 2.0 is allowed Hyperfoil will start with HTTP 1.1 and perform protocol upgrade to 2.0.                      |
+| directHttp2      | false                   | Start with H2C HTTP 2.0 without protocol upgrade. Makes sense only for plain text (`http`) connections. Currently not implemented.                                                                                                                                                     |
+| maxHttp2Streams  | 100                     | Maximum number of requests concurrently enqueued on single HTTP 2.0 connection.                                                                                                                                                                                                        |
+| pipeliningLimit  | 1                       | Maximum number of requests pipelined on single HTTP 1.1 connection.                                                                                                                                                                                                                    |
+| rawBytesHandlers | true                    | Enable or disable using handlers that process HTTP response raw bytes.                                                                                                                                                                                                                 |
+| [keyManager](#keymanager-configuration) |                         | TLS key manager for setting up client certificates.                                                                                                                                                                                                                                    |
+| [trustManager](#trustmanager-configuration) |                         | TLS trust manager for setting up server certificates.                                                                                                                                                                                                                                  |
+| useHttpCache     | false                   | Make use of HTTP cache on client-side. If multiple authorities are involved, disable the HTTP cache for all of them to achieve the desired outcomes. The default is `false`.                                                    |
 
 ## Shared connections
 

--- a/http/src/main/java/io/hyperfoil/http/config/HttpBuilder.java
+++ b/http/src/main/java/io/hyperfoil/http/config/HttpBuilder.java
@@ -59,7 +59,7 @@ public class HttpBuilder implements BuilderBase<HttpBuilder> {
    private KeyManagerBuilder keyManager = new KeyManagerBuilder(this);
    private TrustManagerBuilder trustManager = new TrustManagerBuilder(this);
    private ConnectionStrategy connectionStrategy = ConnectionStrategy.SHARED_POOL;
-   private boolean useHttpCache = true;
+   private boolean useHttpCache = false;
 
    public static HttpBuilder forTesting() {
       return new HttpBuilder(null);

--- a/http/src/test/java/io/hyperfoil/http/cache/HttpCacheEnablementTest.java
+++ b/http/src/test/java/io/hyperfoil/http/cache/HttpCacheEnablementTest.java
@@ -38,9 +38,9 @@ public class HttpCacheEnablementTest extends BaseHttpScenarioTest {
    }
 
    @Test
-   public void testOkWithCacheByDefaultHttp1x() {
+   public void testOkWithoutCacheByDefaultHttp1x() {
       http().sharedConnections(1);
-      testSingle("/ok", true);
+      testSingle("/ok", false);
    }
 
    private void testSingle(String path, boolean isUsingCache) {


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

I would propose to disable the HTTP cache by default in all benchmarks.

From my understanding most of use cases do not use the HTTP cache and given that creating HTTP cache is quite resource consuming, I am proposing to disable it by default.

Users can still enable it by adding `useHttpCache: true` in the `http` entry.

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>