### PR TITLE
Remove branch checks in workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,6 @@ jobs:
       # Push the current version to quay.io, either the tag or snapshot version
 
     - name: Push image version ${{ env.SNAPSHOT_VERSION }}
-      if: matrix.os == 'ubuntu-latest' && env.QUAY_BOT_LOGIN != '' && github.ref == 'refs/heads/master' && endsWith(env.SNAPSHOT_VERSION, 'SNAPSHOT')
+      if: matrix.os == 'ubuntu-latest' && env.QUAY_BOT_LOGIN != '' && github.ref == 'refs/heads/master'
       run: docker push quay.io/hyperfoil/hyperfoil:${{ env.SNAPSHOT_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   build-and-release:
     name: Build & Release
-    if: github.ref != 'refs/heads/master' && endsWith(github.ref, env.RELEASE_BRANCH)
+    if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
     env:
       ENVIRONMENT: CI


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Fixes Issue

Fixes:

```
[Invalid workflow file: .github/workflows/release.yml#L10](https://github.com/Hyperfoil/Hyperfoil/actions/runs/15275297928/workflow)
The workflow is not valid. .github/workflows/release.yml (Line: 10, Col: 9): Unrecognized named-value: 'env'. Located at position 59 within expression: github.ref != 'refs/heads/master' && endsWith(github.ref, env.RELEASE_BRANCH)
```

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>