### PR TITLE
Add option to limit max length in downloadLog

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/deployment/Deployer.java
+++ b/api/src/main/java/io/hyperfoil/api/deployment/Deployer.java
@@ -14,9 +14,10 @@ public interface Deployer extends Closeable {
 
    boolean hasControllerLog();
 
-   void downloadControllerLog(long offset, String destinationFile, Handler<AsyncResult<Void>> handler);
+   void downloadControllerLog(long offset, long maxLength, String destinationFile, Handler<AsyncResult<Void>> handler);
 
-   void downloadAgentLog(DeployedAgent deployedAgent, long offset, String destinationFile, Handler<AsyncResult<Void>> handler);
+   void downloadAgentLog(DeployedAgent deployedAgent, long offset, long maxLength, String destinationFile,
+         Handler<AsyncResult<Void>> handler);
 
    interface Factory {
       String name();

--- a/cli/src/main/java/io/hyperfoil/cli/commands/Log.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Log.java
@@ -47,7 +47,7 @@ public class Log extends ServerCommand {
          }
       }
 
-      String newLogId = invocation.context().client().downloadLog(node, logId, offset, logFile);
+      String newLogId = invocation.context().client().downloadLog(node, logId, offset, Long.MAX_VALUE, logFile);
       // when the agent did not start correctly the newLogId will be null (as we use deployment ID for that)
       // and we won't store it at all.
       if (newLogId != null) {

--- a/cli/src/main/java/io/hyperfoil/client/RestClient.java
+++ b/cli/src/main/java/io/hyperfoil/client/RestClient.java
@@ -283,13 +283,13 @@ public class RestClient implements Client, Closeable {
    }
 
    @Override
-   public String downloadLog(String node, String logId, long offset, File destinationFile) {
+   public String downloadLog(String node, String logId, long offset, long maxLength, File destinationFile) {
       String url = "/log" + (node == null ? "" : "/" + node);
       // When there's no more data, content-length won't be present and the body is null
       // the etag does not match
       CompletableFuture<String> future = new CompletableFuture<>();
       vertx.runOnContext(ctx -> {
-         HttpRequest<Buffer> request = request(HttpMethod.GET, url + "?offset=" + offset);
+         HttpRequest<Buffer> request = request(HttpMethod.GET, url + "?offset=" + offset + "&maxLength=" + maxLength);
          if (logId != null) {
             request.putHeader(HttpHeaders.IF_MATCH.toString(), logId);
          }

--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
@@ -1089,17 +1089,19 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
    }
 
    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
-   public void downloadControllerLog(long offset, File tempFile, Handler<AsyncResult<Void>> handler) {
-      vertx.executeBlocking(future -> deployer.downloadControllerLog(offset, tempFile.toString(), handler), result -> {
-         if (result.failed()) {
-            handler.handle(Future.failedFuture(result.cause()));
-         }
-      });
+   public void downloadControllerLog(long offset, long maxLength, File tempFile, Handler<AsyncResult<Void>> handler) {
+      vertx.executeBlocking(future -> deployer.downloadControllerLog(offset, maxLength, tempFile.toString(), handler),
+            result -> {
+               if (result.failed()) {
+                  handler.handle(Future.failedFuture(result.cause()));
+               }
+            });
    }
 
    @SuppressWarnings("deprecation") // Uses a deprecated executeBlocking call that should be addressed later. This is tracked in https://github.com/Hyperfoil/Hyperfoil/issues/493
-   public void downloadAgentLog(DeployedAgent deployedAgent, long offset, File tempFile, Handler<AsyncResult<Void>> handler) {
-      vertx.executeBlocking(future -> deployer.downloadAgentLog(deployedAgent, offset, tempFile.toString(), handler),
+   public void downloadAgentLog(DeployedAgent deployedAgent, long offset, long maxLength, File tempFile,
+         Handler<AsyncResult<Void>> handler) {
+      vertx.executeBlocking(future -> deployer.downloadAgentLog(deployedAgent, offset, maxLength, tempFile.toString(), handler),
             result -> {
                if (result.failed()) {
                   handler.handle(Future.failedFuture(result.cause()));

--- a/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployer.java
+++ b/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployer.java
@@ -117,17 +117,17 @@ public class SshDeployer implements Deployer {
    }
 
    @Override
-   public void downloadControllerLog(long offset, String destinationFile, Handler<AsyncResult<Void>> handler) {
+   public void downloadControllerLog(long offset, long maxLength, String destinationFile, Handler<AsyncResult<Void>> handler) {
       throw new UnsupportedOperationException();
    }
 
    @Override
-   public void downloadAgentLog(DeployedAgent deployedAgent, long offset, String destinationFile,
+   public void downloadAgentLog(DeployedAgent deployedAgent, long offset, long maxLength, String destinationFile,
          Handler<AsyncResult<Void>> handler) {
       SshDeployedAgent sshAgent = (SshDeployedAgent) deployedAgent;
       try {
          ClientSession session = connectAndLogin(sshAgent.sshKey, sshAgent.username, sshAgent.hostname, sshAgent.port);
-         sshAgent.downloadLog(session, offset, destinationFile, handler);
+         sshAgent.downloadLog(session, offset, maxLength, destinationFile, handler);
       } catch (IOException | DeploymentException | GeneralSecurityException e) {
          handler.handle(Future.failedFuture(e));
       }

--- a/controller-api/src/main/java/io/hyperfoil/controller/Client.java
+++ b/controller-api/src/main/java/io/hyperfoil/controller/Client.java
@@ -44,7 +44,7 @@ public interface Client {
 
    Collection<String> agents();
 
-   String downloadLog(String node, String logId, long offset, File destinationFile);
+   String downloadLog(String node, String logId, long offset, long maxLength, File destinationFile);
 
    void shutdown(boolean force);
 

--- a/controller-api/src/main/resources/openapi.yaml
+++ b/controller-api/src/main/resources/openapi.yaml
@@ -673,6 +673,12 @@ paths:
           type: integer
           format: long
           default: 0
+      - in: query
+        name: maxLength
+        schema:
+          type: integer
+          format: long
+          default: -1
       - in: header
         name: if-match
         description: Identifier of the previously downloaded log chunk.
@@ -701,6 +707,12 @@ paths:
           type: integer
           format: long
           default: 0
+      - in: query
+        name: maxLength
+        schema:
+          type: integer
+          format: long
+          default: -1
       - in: header
         name: if-match
         description: Identifier of the previously downloaded log chunk.


### PR DESCRIPTION
When the agent has a lot of errors, downloading the logs can take a long time, leading to timeouts. This PR adds an option to the download endpoint to set a maximum size.

I tested this with SSH agents but I don't have a k8s test setup.