### PR TITLE
Changing percentiles to save computing their percentage value

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/statistics/StatisticsSnapshot.java
+++ b/api/src/main/java/io/hyperfoil/api/statistics/StatisticsSnapshot.java
@@ -109,7 +109,7 @@ public class StatisticsSnapshot implements Serializable {
 
    public TreeMap<Double, Long> getPercentiles(double[] percentiles) {
       return DoubleStream.of(percentiles).collect(TreeMap::new,
-            (map, p) -> map.put(p * 100, histogram.getValueAtPercentile(p * 100)), TreeMap::putAll);
+            (map, p) -> map.put(p, histogram.getValueAtPercentile(p)), TreeMap::putAll);
    }
 
    public long errors() {

--- a/api/src/main/java/io/hyperfoil/api/statistics/StatisticsSummary.java
+++ b/api/src/main/java/io/hyperfoil/api/statistics/StatisticsSummary.java
@@ -60,7 +60,7 @@ public class StatisticsSummary {
       writer.print("Requests,Responses,Mean,StdDev,Min,");
       for (double p : percentiles) {
          writer.print('p');
-         writer.print(p * 100);
+         writer.print(p);
          writer.print(',');
       }
       writer.print("Max,ConnectionErrors,RequestTimeouts,InternalErrors,Invalid,BlockedTime");

--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -68,6 +68,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/clustering/src/main/java/io/hyperfoil/controller/StatisticsStore.java
+++ b/clustering/src/main/java/io/hyperfoil/controller/StatisticsStore.java
@@ -25,7 +25,7 @@ import io.hyperfoil.controller.model.RequestStats;
 import io.hyperfoil.core.util.LowHigh;
 
 public class StatisticsStore {
-   static final double[] PERCENTILES = new double[] { 0.5, 0.9, 0.99, 0.999, 0.9999 };
+   static final double[] PERCENTILES = new double[] { 50, 90, 99, 99.9, 99.99 };
    private static final Comparator<RequestStats> REQUEST_STATS_COMPARATOR = Comparator
          .<RequestStats, Long> comparing(rs -> rs.summary.startTime)
          .thenComparing(rs -> rs.phase).thenComparing(rs -> rs.metric);

--- a/clustering/src/test/java/io/hyperfoil/controller/CsvWriterTest.java
+++ b/clustering/src/test/java/io/hyperfoil/controller/CsvWriterTest.java
@@ -1,0 +1,33 @@
+package io.hyperfoil.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.hyperfoil.api.config.Benchmark;
+
+public class CsvWriterTest {
+
+   @Test
+   public void testWriteCsvProducesCorrectHeader(@TempDir Path dir) throws IOException {
+      StatisticsStore store = new StatisticsStore(Benchmark.forTesting(), f -> {
+      });
+      CsvWriter.writeCsv(dir, store);
+
+      List<String> lines = Files.readAllLines(dir.resolve("total.csv"));
+      assertFalse(lines.isEmpty());
+      String expected = "Phase,Metric,Start,End," +
+            "Requests,Responses,Mean,StdDev,Min," +
+            "p50.0,p90.0,p99.0,p99.9,p99.99,Max" +
+            ",ConnectionErrors,RequestTimeouts,InternalErrors,Invalid,BlockedTime" +
+            ",MinSessions,MaxSessions";
+      assertEquals(expected, lines.get(0));
+   }
+}

--- a/clustering/src/test/java/io/hyperfoil/controller/JsonWriterTest.java
+++ b/clustering/src/test/java/io/hyperfoil/controller/JsonWriterTest.java
@@ -1,0 +1,69 @@
+package io.hyperfoil.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.hyperfoil.api.config.Benchmark;
+import io.hyperfoil.api.config.SLA;
+import io.hyperfoil.api.statistics.StatisticsSnapshot;
+import io.vertx.core.json.JsonObject;
+
+public class JsonWriterTest {
+
+   @Test
+   public void shouldComputePercentileResponseTimeForFailure() throws Exception {
+      var benchmark = Benchmark.forTesting();
+      StatisticsStore store = new StatisticsStore(benchmark, f -> {
+      });
+      StatisticsSnapshot snapshot = new StatisticsSnapshot();
+      var samples = new long[] { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
+      var histo = snapshot.histogram;
+      for (long sample : samples) {
+         histo.recordValue(sample);
+      }
+      // create a copy of the histogram
+      var latencies = snapshot.histogram.copy();
+      // inject a failure using that snapshot
+      SLA.Failure failure = new SLA.Failure(null, "phase1", "metric1", snapshot, "cause");
+      store.addFailure(failure);
+
+      // capture JSON output
+      StringWriter writer = new StringWriter();
+      JsonFactory jfactory = new JsonFactory();
+      jfactory.setCodec(new ObjectMapper());
+      try (JsonGenerator jGenerator = jfactory.createGenerator(writer)) {
+         JsonWriter.writeArrayJsons(store, jGenerator, new JsonObject());
+      }
+
+      // parse and verify percentiles
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode root = mapper.readTree(writer.toString());
+      JsonNode p = root.path("failures").get(0).path("percentileResponseTime");
+      String[] expectedPercentiles = { "50.0", "90.0", "99.0", "99.9", "99.99" };
+      assertEquals(expectedPercentiles.length, p.size());
+      var names = p.fieldNames();
+      for (int i = 0; i < expectedPercentiles.length; i++) {
+         assertEquals(expectedPercentiles[i], names.next());
+      }
+      double[] expectedPerentileValues = new double[] {
+            latencies.getValueAtPercentile(50.0),
+            latencies.getValueAtPercentile(90.0),
+            latencies.getValueAtPercentile(99.0),
+            latencies.getValueAtPercentile(99.9),
+            latencies.getValueAtPercentile(99.99)
+      };
+      for (int i = 0; i < expectedPerentileValues.length; i++) {
+         String percentileName = expectedPercentiles[i];
+         double expectedValue = expectedPerentileValues[i];
+         assertEquals(expectedValue, p.get(percentileName).asDouble(), "Percentile " + percentileName);
+      }
+   }
+}

--- a/clustering/src/test/java/io/hyperfoil/controller/JsonWriterTest.java
+++ b/clustering/src/test/java/io/hyperfoil/controller/JsonWriterTest.java
@@ -53,16 +53,16 @@ public class JsonWriterTest {
       for (int i = 0; i < expectedPercentiles.length; i++) {
          assertEquals(expectedPercentiles[i], names.next());
       }
-      double[] expectedPerentileValues = new double[] {
+      double[] expectedPercentileValues = new double[] {
             latencies.getValueAtPercentile(50.0),
             latencies.getValueAtPercentile(90.0),
             latencies.getValueAtPercentile(99.0),
             latencies.getValueAtPercentile(99.9),
             latencies.getValueAtPercentile(99.99)
       };
-      for (int i = 0; i < expectedPerentileValues.length; i++) {
+      for (int i = 0; i < expectedPercentileValues.length; i++) {
          String percentileName = expectedPercentiles[i];
-         double expectedValue = expectedPerentileValues[i];
+         double expectedValue = expectedPercentileValues[i];
          assertEquals(expectedValue, p.get(percentileName).asDouble(), "Percentile " + percentileName);
       }
    }


### PR DESCRIPTION
While working on #589 I've found rather error-prone to add a single percentile class, causing several math errors due to rounding the percentile * 100,
This change aim to fix this while adding few tests to verify there is no impact in the changes.