### PR TITLE
Track and save interval histograms per agent

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,4 +1,4 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=21.0.7-tem
+java=21.0.8-tem
 maven=3.9.8

--- a/api/src/main/java/io/hyperfoil/api/statistics/Statistics.java
+++ b/api/src/main/java/io/hyperfoil/api/statistics/Statistics.java
@@ -50,7 +50,7 @@ public class Statistics {
       active = new AtomicReferenceArray<>(16);
       inactive = new AtomicReferenceArray<>(16);
       StatisticsSnapshot first = new StatisticsSnapshot();
-      first.sequenceId = 0;
+      first.sampleId = 0;
       active.set(0, first);
       highestTrackableValue = first.histogram.getHighestTrackableValue();
    }
@@ -263,25 +263,25 @@ public class Statistics {
    }
 
    private StatisticsSnapshot active(long timestamp) {
-      int index = (int) ((timestamp - startTimestamp) / SAMPLING_PERIOD_MILLIS);
+      int sampleId = (int) ((timestamp - startTimestamp) / SAMPLING_PERIOD_MILLIS);
       AtomicReferenceArray<StatisticsSnapshot> active = this.active;
-      if (index >= active.length()) {
-         index = active.length() - 1;
-      } else if (index < 0) {
+      if (sampleId >= active.length()) {
+         sampleId = active.length() - 1;
+      } else if (sampleId < 0) {
          log.error("Record start timestamp {} predates statistics start {}", timestamp, startTimestamp);
-         index = 0;
+         sampleId = 0;
       }
-      StatisticsSnapshot snapshot = active.get(index);
+      StatisticsSnapshot snapshot = active.get(sampleId);
       if (snapshot == null) {
          snapshot = new StatisticsSnapshot();
-         snapshot.sequenceId = index;
-         active.set(index, snapshot);
+         snapshot.sampleId = sampleId;
+         active.set(sampleId, snapshot);
       }
-      lowestActiveUpdater.accumulateAndGet(this, index, Math::min);
+      lowestActiveUpdater.accumulateAndGet(this, sampleId, Math::min);
       // Highest active is increasing monotonically and it is updated only by the event-loop thread;
       // therefore we don't have to use CAS operation
-      if (index > highestActive) {
-         highestActive = index;
+      if (sampleId > highestActive) {
+         highestActive = sampleId;
       }
       return snapshot;
    }

--- a/api/src/main/java/io/hyperfoil/api/statistics/StatisticsSnapshot.java
+++ b/api/src/main/java/io/hyperfoil/api/statistics/StatisticsSnapshot.java
@@ -13,7 +13,8 @@ import org.HdrHistogram.Histogram;
  * Non-thread safe mutable set of values.
  */
 public class StatisticsSnapshot implements Serializable {
-   public int sequenceId = -1;
+   // used to track the current sample id over time
+   public int sampleId = -1;
    public final Histogram histogram = new Histogram(TimeUnit.MINUTES.toNanos(1), 2);
    public int requestCount;
    public int responseCount;
@@ -47,7 +48,7 @@ public class StatisticsSnapshot implements Serializable {
 
    public StatisticsSnapshot clone() {
       StatisticsSnapshot copy = new StatisticsSnapshot();
-      copy.sequenceId = sequenceId;
+      copy.sampleId = sampleId;
       copy.add(this);
       return copy;
    }
@@ -119,7 +120,7 @@ public class StatisticsSnapshot implements Serializable {
    @Override
    public String toString() {
       return "StatisticsSnapshot{" +
-            "sequenceId=" + sequenceId +
+            "sequenceId=" + sampleId +
             ", start=" + histogram.getStartTimeStamp() +
             ", end=" + histogram.getEndTimeStamp() +
             ", requestCount=" + requestCount +

--- a/api/src/main/java/io/hyperfoil/internal/Controller.java
+++ b/api/src/main/java/io/hyperfoil/internal/Controller.java
@@ -15,6 +15,7 @@ public interface Controller {
    Path BENCHMARK_DIR = Properties.get(Properties.BENCHMARK_DIR, Paths::get, ROOT_DIR.resolve("benchmark"));
    Path HOOKS_DIR = ROOT_DIR.resolve("hooks");
    Path RUN_DIR = Properties.get(Properties.RUN_DIR, Paths::get, ROOT_DIR.resolve("run"));
+   Boolean PERSIST_HDR = Properties.getBoolean(Properties.CONTROLLER_PERSIST_HDR);
 
    String host();
 

--- a/api/src/main/java/io/hyperfoil/internal/Controller.java
+++ b/api/src/main/java/io/hyperfoil/internal/Controller.java
@@ -15,7 +15,7 @@ public interface Controller {
    Path BENCHMARK_DIR = Properties.get(Properties.BENCHMARK_DIR, Paths::get, ROOT_DIR.resolve("benchmark"));
    Path HOOKS_DIR = ROOT_DIR.resolve("hooks");
    Path RUN_DIR = Properties.get(Properties.RUN_DIR, Paths::get, ROOT_DIR.resolve("run"));
-   Boolean PERSIST_HDR = Properties.getBoolean(Properties.CONTROLLER_PERSIST_HDR);
+   boolean PERSIST_HDR = Properties.getBoolean(Properties.CONTROLLER_PERSIST_HDR);
 
    String host();
 

--- a/api/src/main/java/io/hyperfoil/internal/Properties.java
+++ b/api/src/main/java/io/hyperfoil/internal/Properties.java
@@ -22,6 +22,7 @@ public interface Properties {
    String CONTROLLER_LOG = "io.hyperfoil.controller.log.file";
    String CONTROLLER_LOG_LEVEL = "io.hyperfoil.controller.log.level";
    String CONTROLLER_PORT = "io.hyperfoil.controller.port";
+   String CONTROLLER_PERSIST_HDR = "io.hyperfoil.controller.persist.hdr";
    String CPU_WATCHDOG_PERIOD = "io.hyperfoil.cpu.watchdog.period";
    String CPU_WATCHDOG_IDLE_THRESHOLD = "io.hyperfoil.cpu.watchdog.idle.threshold";
    String DEPLOYER = "io.hyperfoil.deployer";

--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
@@ -57,6 +57,7 @@ import io.hyperfoil.clustering.messages.SessionStatsMessage;
 import io.hyperfoil.clustering.messages.StatsMessage;
 import io.hyperfoil.clustering.util.PersistenceUtil;
 import io.hyperfoil.controller.CsvWriter;
+import io.hyperfoil.controller.HdrWriter;
 import io.hyperfoil.controller.JsonLoader;
 import io.hyperfoil.controller.JsonWriter;
 import io.hyperfoil.controller.StatisticsStore;
@@ -183,13 +184,13 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
                   if (log.isDebugEnabled()) {
                      log.debug("Run {}: Received stats from {}({}): {}/{}/{}:{} ({} requests) - added:{}",
                            rsm.runId, agentName, rsm.address, phase, rsm.stepId, rsm.metric,
-                           rsm.statistics.sequenceId, rsm.statistics.requestCount, added);
+                           rsm.statistics.sampleId, rsm.statistics.requestCount, added);
                   }
                   if (!added) {
                      // warning already logged
                      String errorMessage = String.format(
                            "Received statistics for %s/%d/%s:%d with %d requests but the statistics are already completed; these statistics won't be reported.",
-                           phase, rsm.stepId, rsm.metric, rsm.statistics.sequenceId, rsm.statistics.requestCount);
+                           phase, rsm.stepId, rsm.metric, rsm.statistics.sampleId, rsm.statistics.requestCount);
                      log.error(errorMessage);
                      run.errors.add(new Run.Error(null, new BenchmarkExecutionException(errorMessage)));
                   }
@@ -433,9 +434,9 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       }
       log.info("Loading stats from {}", jsonPath);
       StatisticsStore store = new StatisticsStore(benchmark, f -> {
-      });
+      }, Controller.PERSIST_HDR);
       try {
-         JsonLoader.read(Files.readString(jsonPath, StandardCharsets.UTF_8), store);
+         JsonLoader.read(Files.readString(jsonPath, StandardCharsets.UTF_8), store, Controller.PERSIST_HDR);
       } catch (Exception e) {
          log.error("Cannot load stats from {}", jsonPath, e);
          return null;
@@ -503,7 +504,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
       runDir.toFile().mkdirs();
       Run run = new Run(runId, runDir, benchmark);
       run.initStore(new StatisticsStore(benchmark, failure -> log.warn("Failed verify SLA(s) for {}/{}: {}",
-            failure.phase(), failure.metric(), failure.message())));
+            failure.phase(), failure.metric(), failure.message()), Controller.PERSIST_HDR));
       run.description = description;
       runs.put(run.id, run);
       if (run.benchmark.source() != null) {
@@ -794,6 +795,16 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
          } catch (IOException e) {
             log.error("Failed to persist statistics", e);
             future.fail(e);
+         }
+
+         if (Controller.PERSIST_HDR) {
+            // by default skip downloading the HDRs
+            try {
+               HdrWriter.writeHdr(run.dir.resolve("hdr"), run.statisticsStore());
+            } catch (IOException e) {
+               log.error("Failed to persist hdr statistics", e);
+               future.fail(e);
+            }
          }
 
          JsonObject info = new JsonObject()

--- a/clustering/src/main/java/io/hyperfoil/clustering/RequestStatsSender.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/RequestStatsSender.java
@@ -34,7 +34,7 @@ public class RequestStatsSender extends StatisticsCollector {
    private void sendStats(Phase phase, int stepId, String metric, StatisticsSnapshot statistics, CountDown countDown) {
       if (statistics.histogram.getEndTimeStamp() >= statistics.histogram.getStartTimeStamp()) {
          log.debug("Sending stats for {} {}/{}, id {}: {} requests, {} responses", phase.name(), stepId, metric,
-               statistics.sequenceId, statistics.requestCount, statistics.responseCount);
+               statistics.sampleId, statistics.requestCount, statistics.responseCount);
          // On clustered eventbus, ObjectCodec is not called synchronously so we *must* do a copy here.
          // (on a local eventbus we'd have to do a copy in transform() anyway)
          StatisticsSnapshot copy = statistics.clone();

--- a/clustering/src/main/java/io/hyperfoil/controller/Data.java
+++ b/clustering/src/main/java/io/hyperfoil/controller/Data.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.HdrHistogram.Histogram;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -27,19 +28,22 @@ final class Data {
    final int stepId;
    final String metric;
    // for reporting
+   private final Boolean trackIntervalHistograms;
    final StatisticsSnapshot total = new StatisticsSnapshot();
    final Map<String, StatisticsSnapshot> perAgent = new HashMap<>();
    final Map<String, IntObjectMap<StatisticsSnapshot>> lastStats = new HashMap<>();
    final List<StatisticsSummary> series = new ArrayList<>();
+   final Map<String, List<Histogram>> intervalHistogramsPerAgent = new HashMap<>();;
+   final List<Histogram> intervalHistograms = new ArrayList<>();
    final Map<String, List<StatisticsSummary>> agentSeries = new HashMap<>();
    // floating statistics for SLAs
    private final Map<SLA, StatisticsStore.Window> windowSlas;
    private final SLA[] totalSlas;
-   private int highestSequenceId = 0;
+   private int highestSampleId = 0;
    private boolean completed;
 
    Data(StatisticsStore statisticsStore, String phase, boolean isWarmup, int stepId, String metric,
-         Map<SLA, StatisticsStore.Window> periodSlas, SLA[] totalSlas) {
+         Map<SLA, StatisticsStore.Window> periodSlas, SLA[] totalSlas, Boolean trackIntervalHistograms) {
       this.statisticsStore = statisticsStore;
       this.phase = phase;
       this.isWarmup = isWarmup;
@@ -47,6 +51,7 @@ final class Data {
       this.metric = metric;
       this.windowSlas = periodSlas;
       this.totalSlas = totalSlas;
+      this.trackIntervalHistograms = trackIntervalHistograms;
    }
 
    boolean record(String agentName, StatisticsSnapshot stats) {
@@ -56,15 +61,15 @@ final class Data {
       total.add(stats);
       perAgent.computeIfAbsent(agentName, a -> new StatisticsSnapshot()).add(stats);
       IntObjectMap<StatisticsSnapshot> partialSnapshots = lastStats.computeIfAbsent(agentName, a -> new IntObjectHashMap<>());
-      StatisticsSnapshot partialSnapshot = partialSnapshots.get(stats.sequenceId);
+      StatisticsSnapshot partialSnapshot = partialSnapshots.get(stats.sampleId);
       if (partialSnapshot == null) {
-         partialSnapshots.put(stats.sequenceId, stats);
+         partialSnapshots.put(stats.sampleId, stats);
       } else {
          partialSnapshot.add(stats);
       }
-      while (stats.sequenceId > highestSequenceId) {
-         ++highestSequenceId;
-         int mergedSequenceId = highestSequenceId - MERGE_DELAY;
+      while (stats.sampleId > highestSampleId) {
+         ++highestSampleId;
+         int mergedSequenceId = highestSampleId - MERGE_DELAY;
          if (mergedSequenceId < 0) {
             continue;
          }
@@ -81,10 +86,18 @@ final class Data {
             sum.add(snapshot);
             agentSeries.computeIfAbsent(entry.getKey(), a -> new ArrayList<>())
                   .add(snapshot.summary(StatisticsStore.PERCENTILES));
+            if (trackIntervalHistograms) {
+               // interval histograms per agent
+               intervalHistogramsPerAgent.computeIfAbsent(entry.getKey(), a -> new ArrayList<>())
+                     .add(snapshot.histogram);
+            }
          }
       }
       if (!sum.isEmpty()) {
          series.add(sum.summary(StatisticsStore.PERCENTILES));
+         if (trackIntervalHistograms) {
+            intervalHistograms.add(sum.histogram);
+         }
       }
       for (Map.Entry<SLA, StatisticsStore.Window> entry : windowSlas.entrySet()) {
          SLA sla = entry.getKey();
@@ -101,7 +114,7 @@ final class Data {
    }
 
    void completePhase() {
-      for (int i = Math.max(0, highestSequenceId - MERGE_DELAY); i <= highestSequenceId; ++i) {
+      for (int i = Math.max(0, highestSampleId - MERGE_DELAY); i <= highestSampleId; ++i) {
          mergeSnapshots(i);
       }
       // Just sanity checks

--- a/clustering/src/main/java/io/hyperfoil/controller/Data.java
+++ b/clustering/src/main/java/io/hyperfoil/controller/Data.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.controller;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,13 +29,13 @@ final class Data {
    final int stepId;
    final String metric;
    // for reporting
-   private final Boolean trackIntervalHistograms;
+   private final boolean trackIntervalHistograms;
    final StatisticsSnapshot total = new StatisticsSnapshot();
    final Map<String, StatisticsSnapshot> perAgent = new HashMap<>();
    final Map<String, IntObjectMap<StatisticsSnapshot>> lastStats = new HashMap<>();
    final List<StatisticsSummary> series = new ArrayList<>();
-   final Map<String, List<Histogram>> intervalHistogramsPerAgent = new HashMap<>();;
-   final List<Histogram> intervalHistograms = new ArrayList<>();
+   final Map<String, List<Histogram>> intervalHistogramsPerAgent;
+   final List<Histogram> intervalHistograms;
    final Map<String, List<StatisticsSummary>> agentSeries = new HashMap<>();
    // floating statistics for SLAs
    private final Map<SLA, StatisticsStore.Window> windowSlas;
@@ -43,7 +44,7 @@ final class Data {
    private boolean completed;
 
    Data(StatisticsStore statisticsStore, String phase, boolean isWarmup, int stepId, String metric,
-         Map<SLA, StatisticsStore.Window> periodSlas, SLA[] totalSlas, Boolean trackIntervalHistograms) {
+         Map<SLA, StatisticsStore.Window> periodSlas, SLA[] totalSlas, boolean trackIntervalHistograms) {
       this.statisticsStore = statisticsStore;
       this.phase = phase;
       this.isWarmup = isWarmup;
@@ -52,6 +53,8 @@ final class Data {
       this.windowSlas = periodSlas;
       this.totalSlas = totalSlas;
       this.trackIntervalHistograms = trackIntervalHistograms;
+      this.intervalHistogramsPerAgent = trackIntervalHistograms ? new HashMap<>() : Collections.emptyMap();
+      this.intervalHistograms = trackIntervalHistograms ? new ArrayList<>() : Collections.emptyList();
    }
 
    boolean record(String agentName, StatisticsSnapshot stats) {

--- a/clustering/src/main/java/io/hyperfoil/controller/HdrWriter.java
+++ b/clustering/src/main/java/io/hyperfoil/controller/HdrWriter.java
@@ -1,0 +1,65 @@
+package io.hyperfoil.controller;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.HistogramLogWriter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class HdrWriter {
+   private static final Logger log = LogManager.getLogger(HdrWriter.class);
+
+   public static void writeHdr(Path dir, StatisticsStore store) throws IOException {
+      WriterUtil.createLocalDir(dir);
+
+      Data[] sorted = store.data.values().stream().flatMap(map -> map.values().stream()).toArray(Data[]::new);
+      Arrays.sort(sorted,
+            Comparator.comparing((Data d) -> d.total.histogram.getStartTimeStamp()).thenComparing(d -> d.phase)
+                  .thenComparing(d -> d.total.histogram.getEndTimeStamp()).thenComparing(d -> d.metric)
+                  .thenComparingInt(d -> d.stepId));
+
+      try (PrintStream totalStream = new PrintStream(dir + File.separator + "total.hgrm")) {
+         // global hgrm containing all histograms for all phases
+         HistogramLogWriter histLogWriter = new HistogramLogWriter(totalStream);
+         histLogWriter.outputLogFormatVersion();
+         histLogWriter.outputLegend();
+
+         for (Data data : sorted) {
+            try (PrintStream byPhaseStream = new PrintStream(
+                  dir + File.separator + WriterUtil.sanitize(data.phase) + "." + WriterUtil.sanitize(data.metric)
+                        + ".hgrm")) {
+
+               for (Map.Entry<String, List<Histogram>> agentIntervalHistograms : data.intervalHistogramsPerAgent.entrySet()) {
+                  agentIntervalHistograms.getValue().forEach(hist -> {
+                     hist.setTag(getTag(agentIntervalHistograms.getKey(), data));
+                     histLogWriter.outputIntervalHistogram(hist);
+                  });
+               }
+
+               // load the merged intervals among all agents if more than one agent is configured
+               if (data.intervalHistogramsPerAgent.size() > 1) {
+                  data.intervalHistograms.forEach(hist -> {
+                     hist.setTag(getTag("merged", data));
+                     histLogWriter.outputIntervalHistogram(hist);
+                  });
+               }
+
+               // save the phase-specific histogram
+               data.total.histogram.outputPercentileDistribution(byPhaseStream, 1.0);
+            }
+         }
+      }
+   }
+
+   private static String getTag(String agent, Data d) {
+      return agent + "/" + d.phase + "/" + d.metric + "/" + (d.isWarmup ? "warmup" : "");
+   }
+}

--- a/clustering/src/main/java/io/hyperfoil/controller/JsonLoader.java
+++ b/clustering/src/main/java/io/hyperfoil/controller/JsonLoader.java
@@ -19,7 +19,7 @@ import io.vertx.core.json.JsonObject;
 
 public class JsonLoader {
 
-   public static StatisticsStore read(String text, StatisticsStore store) {
+   public static StatisticsStore read(String text, StatisticsStore store, Boolean trackIntervalHistograms) {
       JsonObject object = new JsonObject(text);
       String schema = object.getString("$schema");
       if (!JsonWriter.RUN_SCHEMA.equals(schema)) {
@@ -40,7 +40,7 @@ public class JsonLoader {
       for (Object item : object.getJsonArray("stats")) {
          JsonObject stats = (JsonObject) item;
          Data data = new Data(store, stats.getString("name"), stats.getBoolean("isWarmup"), 0, stats.getString("metric"),
-               Collections.emptyMap(), new SLA[0]);
+               Collections.emptyMap(), new SLA[0], trackIntervalHistograms);
          dataMap.computeIfAbsent(data.phase, p -> new HashMap<>()).putIfAbsent(data.metric, data);
          store.addData(dataCounter++, data.metric, data);
          loadSnapshot(stats.getJsonObject("total"), data.total);
@@ -75,7 +75,8 @@ public class JsonLoader {
             boolean isWarmup = stats.getBoolean("isWarmup");
             Data data = dataMap.computeIfAbsent(phase, p -> new HashMap<>())
                   .computeIfAbsent(metric,
-                        m -> new Data(store, phase, isWarmup, 0, metric, Collections.emptyMap(), new SLA[0]));
+                        m -> new Data(store, phase, isWarmup, 0, metric, Collections.emptyMap(), new SLA[0],
+                              trackIntervalHistograms));
             StatisticsSnapshot snapshot = new StatisticsSnapshot();
             loadSnapshot(stats.getJsonObject("total"), snapshot);
             loadHistogram(stats.getJsonObject("histogram").getJsonArray("linear"), snapshot.histogram);

--- a/clustering/src/main/java/io/hyperfoil/controller/JsonLoader.java
+++ b/clustering/src/main/java/io/hyperfoil/controller/JsonLoader.java
@@ -19,7 +19,7 @@ import io.vertx.core.json.JsonObject;
 
 public class JsonLoader {
 
-   public static StatisticsStore read(String text, StatisticsStore store, Boolean trackIntervalHistograms) {
+   public static StatisticsStore read(String text, StatisticsStore store, boolean trackIntervalHistograms) {
       JsonObject object = new JsonObject(text);
       String schema = object.getString("$schema");
       if (!JsonWriter.RUN_SCHEMA.equals(schema)) {

--- a/clustering/src/main/java/io/hyperfoil/controller/StatisticsStore.java
+++ b/clustering/src/main/java/io/hyperfoil/controller/StatisticsStore.java
@@ -39,9 +39,9 @@ public class StatisticsStore {
    final Map<String, SessionPoolStats> sessionPoolStats = new HashMap<>();
    final Map<String, Map<String, Map<String, List<ConnectionPoolStats>>>> connectionPoolStats = new HashMap<>();
    final Map<String, Map<String, String>> cpuUsage = new HashMap<>();
-   private final Boolean trackIntervalHistograms;
+   private final boolean trackIntervalHistograms;
 
-   public StatisticsStore(Benchmark benchmark, Consumer<SLA.Failure> failureHandler, Boolean trackIntervalHistograms) {
+   public StatisticsStore(Benchmark benchmark, Consumer<SLA.Failure> failureHandler, boolean trackIntervalHistograms) {
       this.benchmark = benchmark;
       this.failureHandler = failureHandler;
       this.slaProviders = benchmark.steps()

--- a/clustering/src/main/java/io/hyperfoil/controller/WriterUtil.java
+++ b/clustering/src/main/java/io/hyperfoil/controller/WriterUtil.java
@@ -1,5 +1,8 @@
 package io.hyperfoil.controller;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -21,6 +24,17 @@ class WriterUtil {
             }
          }
       } while (hadNext);
+   }
+
+   static void createLocalDir(Path dir) throws IOException {
+      File dirAsFile = dir.toFile();
+      if (!dirAsFile.exists() && !dirAsFile.mkdirs()) {
+         throw new IOException("Cannot create directory " + dir);
+      }
+   }
+
+   static String sanitize(String phase) {
+      return phase.replaceAll(File.separator, "_");
    }
 
    @FunctionalInterface

--- a/clustering/src/test/java/io/hyperfoil/controller/HdrWriterTest.java
+++ b/clustering/src/test/java/io/hyperfoil/controller/HdrWriterTest.java
@@ -9,25 +9,22 @@ import java.nio.file.Path;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 
 import io.hyperfoil.api.config.Benchmark;
 
-public class CsvWriterTest {
+public class HdrWriterTest {
 
    @Test
-   public void testWriteCsvProducesCorrectHeader(@TempDir Path dir) throws IOException {
+   public void testPersistHdrs(@TempDir(cleanup = CleanupMode.ALWAYS) Path dir) throws IOException {
       StatisticsStore store = new StatisticsStore(Benchmark.forTesting(), f -> {
-      }, false);
-      CsvWriter.writeCsv(dir, store);
+      }, true);
+      HdrWriter.writeHdr(dir, store);
 
-      List<String> lines = Files.readAllLines(dir.resolve("total.csv"));
+      List<String> lines = Files.readAllLines(dir.resolve("total.hgrm"));
       assertFalse(lines.isEmpty());
-      String expected = "Phase,Metric,Start,End," +
-            "Requests,Responses,Mean,StdDev,Min," +
-            "p50.0,p90.0,p99.0,p99.9,p99.99,Max" +
-            ",ConnectionErrors,RequestTimeouts,InternalErrors,Invalid,BlockedTime" +
-            ",MinSessions,MaxSessions";
+      String expected = "#[Histogram log format version 1.3]";
       assertEquals(expected, lines.getFirst());
    }
 }

--- a/clustering/src/test/java/io/hyperfoil/controller/JsonWriterTest.java
+++ b/clustering/src/test/java/io/hyperfoil/controller/JsonWriterTest.java
@@ -22,7 +22,7 @@ public class JsonWriterTest {
    public void shouldComputePercentileResponseTimeForFailure() throws Exception {
       var benchmark = Benchmark.forTesting();
       StatisticsStore store = new StatisticsStore(benchmark, f -> {
-      });
+      }, false);
       StatisticsSnapshot snapshot = new StatisticsSnapshot();
       var samples = new long[] { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
       var histo = snapshot.histogram;

--- a/core/src/main/java/io/hyperfoil/core/impl/statistics/StatisticsCollector.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/statistics/StatisticsCollector.java
@@ -48,12 +48,12 @@ public class StatisticsCollector implements Consumer<SessionStatistics> {
             String metric = entry.getKey();
             IntObjectMap<StatisticsSnapshot> snapshots = metricMap.computeIfAbsent(metric, k -> new IntObjectHashMap<>());
             entry.getValue().visitSnapshots(snapshot -> {
-               assert snapshot.sequenceId >= 0;
-               StatisticsSnapshot existing = snapshots.get(snapshot.sequenceId);
+               assert snapshot.sampleId >= 0;
+               StatisticsSnapshot existing = snapshots.get(snapshot.sampleId);
                if (existing == null) {
                   existing = new StatisticsSnapshot();
-                  existing.sequenceId = snapshot.sequenceId;
-                  snapshots.put(snapshot.sequenceId, existing);
+                  existing.sampleId = snapshot.sampleId;
+                  snapshots.put(snapshot.sampleId, existing);
                }
 
                if (log.isDebugEnabled()) {

--- a/core/src/test/java/io/hyperfoil/core/session/BaseScenarioTest.java
+++ b/core/src/test/java/io/hyperfoil/core/session/BaseScenarioTest.java
@@ -62,7 +62,7 @@ public abstract class BaseScenarioTest extends BaseBenchmarkParserTest {
       @Override
       public void accept(Phase phase, int stepId, String metric, StatisticsSnapshot snapshot, CountDown countDown) {
          log.debug("Adding stats for {}/{}/{} - #{}: {} requests {} responses", phase.name, stepId, metric,
-               snapshot.sequenceId, snapshot.requestCount, snapshot.responseCount);
+               snapshot.sampleId, snapshot.requestCount, snapshot.responseCount);
          Map<String, StatisticsSnapshot> stats = phaseStats.get(phase.name);
          if (stats == null) {
             stats = new HashMap<>();

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/StartWithDelayTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/StartWithDelayTest.java
@@ -63,7 +63,7 @@ public class StartWithDelayTest extends BaseBenchmarkTest {
 
       StatisticsCollector.StatisticsConsumer statisticsConsumer = (phase, stepId, metric, snapshot, countDown) -> log.debug(
             "Adding stats for {}/{}/{} - #{}: {} requests {} responses", phase, stepId, metric,
-            snapshot.sequenceId, snapshot.requestCount, snapshot.responseCount);
+            snapshot.sampleId, snapshot.requestCount, snapshot.responseCount);
       LocalSimulationRunner runner = new LocalSimulationRunner(benchmark, statisticsConsumer, null, null);
       runner.run();
 

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/ThinkTimeTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/ThinkTimeTest.java
@@ -122,7 +122,7 @@ public class ThinkTimeTest extends BaseBenchmarkTest {
       @Override
       public void accept(Phase phase, int stepId, String metric, StatisticsSnapshot snapshot, CountDown countDown) {
          log.debug("Adding stats for {}/{}/{} - #{}: {} requests {} responses", phase, stepId, metric,
-               snapshot.sequenceId, snapshot.requestCount, snapshot.responseCount);
+               snapshot.sampleId, snapshot.requestCount, snapshot.responseCount);
          stats.computeIfAbsent(metric, n -> new StatisticsSnapshot()).add(snapshot);
       }
 


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

This is still a draft proposal on how we could save HDR histograms per interval and agent.

## Fixes Issue

Fixes https://github.com/Hyperfoil/Hyperfoil/issues/588

## Changes proposed

Tracks interval histograms so that they can be retrieved for further analysis, e.g., using https://hdrhistogram.github.io/HdrHistogramJSDemo/logparser.html or https://hdrhistogram.github.io/HdrHistogram/plotFiles.html

- [x] the tracking is disabled by default but can be enabled via global controller config `-Dio.hyperfoil.controller.persist.hdr=true` 
- [x] tracking interval histograms per agent configured
- [x] tracking global histograms per phase

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>