### PR TITLE
Bump vertx to 4.5.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,10 +87,10 @@
         <version.junit-jupiter-api>5.10.3</version.junit-jupiter-api>
         <version.log4j2>2.25.1</version.log4j2>
         <version.metainf-services>1.8</version.metainf-services>
-        <version.netty.tcnative.boringssl>2.0.70.Final</version.netty.tcnative.boringssl>
+        <version.netty.tcnative.boringssl>2.0.73.Final</version.netty.tcnative.boringssl>
         <version.slf4j>2.0.6</version.slf4j>
         <version.snakeyaml>2.2</version.snakeyaml>
-        <version.vertx>4.5.14</version.vertx>
+        <version.vertx>4.5.21</version.vertx>
         <version.infinispan>15.0.8.Final</version.infinispan>
         <version.jboss-threads>3.5.0.Final</version.jboss-threads>
         <version.jboss-logging>3.6.0.Final</version.jboss-logging>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Upgrade `vertx` and `netty.tcnative.boringssl`

## Changes proposed

- [x] Upgrade `vetx` to `4.5.21`
- [x] Upgrade `netty.tcnative.boringssl` to `2.0.73.Final`

As a consequence upgrade `netty-codec-http2` to `>= 4.1.124.Final` to fix reported vulnerabilities in Quay

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>