### PR TITLE
Bump kubernetes-client to 7.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <version.apache.sshd>2.13.2</version.apache.sshd>
         <version.assertj>3.10.0</version.assertj>
         <version.eddsa>0.3.0</version.eddsa>
-        <version.fabric8.kubernetes-client>4.7.2</version.fabric8.kubernetes-client>
+        <version.fabric8.kubernetes-client>7.4.0</version.fabric8.kubernetes-client>
         <version.jkube.maven-plugin>1.17.0</version.jkube.maven-plugin>
         <version.hdrhistogram>2.1.11</version.hdrhistogram>
         <version.javaparser>3.14.12</version.javaparser>


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

Upgrades `kubernetes-client` to version `7.4.0`

## Changes proposed

Since the bump is quite big (from version `4.x` to version `7.x`) I had to migrate few things in the `K8sDeployer`, in particular how the logs were retrieved.

I did some smoke tests mainly checking the following:
- the pods are properly started
- the load is executed as expected and split evenly among the pods
- the logs are retrievable from the `cli`
- the report can be generated 

Below you can find a step by step guide on how to setup such environment if you are interested

## How I tested

Used `kind` to create a local k8s cluster
```bash
kind create cluster
```

Compile and built the local Hyperfoil image:
```bash
mvn clean install -DskipTests -DskipITs
podman build --platform=linux/amd64 --manifest hyperfoil:local -f distribution/src/main/docker/Dockerfile ./distribution
```

Locally updated the `k8s-deployer/hyperfoil.yaml` file:
```bash
-          image: quay.io/hyperfoil/hyperfoil:latest
+          image: localhost/hyperfoil:local
```

Uploaded the local image into the Kind cluster with:
```bash
podman save localhost/hyperfoil:local -o /tmp/hf.tar
kind load image-archive /tmp/hf.tar
```

Deploy and install the Hyperfoil controller manually (followed https://hyperfoil.io/docs/user-guide/installation/k8s_manual/):
```bash
kubectl create namespace hyperfoil
cat k8s-deployer/hyperfoil.yaml | kubectl apply -f -
```

As a result, running `kubectl get all -n hyperfoil`, you should see:
```bash
NAME                              READY   STATUS    RESTARTS   AGE
pod/controller-67dff9698f-vnpbj   1/1     Running   0          6s

NAME                TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
service/hyperfoil   ClusterIP   <ip>           <none>        8090/TCP   6s

NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/controller   1/1     1            1           6s

NAME                                    DESIRED   CURRENT   READY   AGE
replicaset.apps/controller-67dff9698f   1         1         1       6s
```

Setup a port forwarding to be able to connect from outside of the cluster:
```
kubectl port-forward -n hyperfoil pod/controller-67dff9698f-vnpbj 8090:8090
```

Then start the `cli` from your host and connect with `connect localhost:8090`.

Run a benchmark like this:
```yaml
name: test
http:
- host: https://example.com
  sharedConnections: 10

agents:
  first-agent:
  second-agent:
phases:
- main:
    constantRate:
      maxSessions: 50
      usersPerSec: 2
      duration: 10s
      scenario:
      - testMaestro:
        - httpRequest:
            GET: /
```

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>