### PR TITLE
Update documentation for the 0.28 release

### DIFF
--- a/docs/site/content/en/blog/releases/release_notes.md
+++ b/docs/site/content/en/blog/releases/release_notes.md
@@ -5,10 +5,27 @@ type: docs
 weight: 1
 ---
 
+## 0.28.0 (2025-10-01)
+
+* Upgraded to JDK 21
+* Implemented multi-arch builds for container images
+* Added run persistence monitoring to track benchmark progress
+* Introduced a setting for SSL handshake timeout
+* Added a useHttpCache option in the benchmark JSON schema
+* Allowed the use of local benchmarks for testing purposes
+* Reduced GC pressure and improved efficiency when parsing HTTP headers
+* Implemented allocation-free date parsing to lower memory usage
+* Optimized Content-Length and Transfer-Encoding header matching
+* Added custom wait logic to avoid CPU spinning and reduce idle CPU usage
+* Stopped using a session if its scheduled delay has already expired
+* Fixed an issue where the JsonParser would fail with fragmented responses
+* The deprecated run-local command has been removed
+* Updated major dependencies, including Vert.x, Infinispan, and the Kubernetes client
+
 ## 0.27.1 (2024-11-20)
 
-* Add run persistence monitoring by @lampajr in #499
-* Embed the report template in the clustering module by @lampajr in #503
+* Add run persistence monitoring
+* Embed the report template in the clustering module
 
 ## 0.27 (2024-10-22)
 

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -121,15 +121,16 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: 0.27.1
+  version: 0.28.0
   
   # Uncomment this if your GitHub repo does not have "main" as the default branch,
   # or specify a new value if you want to reference another branch in your GitHub links
-  github_branch: 0.27.x
+  github_branch: 0.28.x
   
   # Custom param: latest distribution url
-  url_latest_distribution: https://github.com/Hyperfoil/Hyperfoil/releases/download/hyperfoil-all-0.27.1/hyperfoil-0.27.1.zip
-  zip_latest_distribution: hyperfoil-0.27.1.zip
+
+  url_latest_distribution: https://github.com/Hyperfoil/Hyperfoil/releases/download/hyperfoil-all-0.28.0/hyperfoil-0.28.0.zip
+  zip_latest_distribution: hyperfoil-0.28.0.zip
   url_all_releases: https://github.com/Hyperfoil/Hyperfoil/releases/
 
   # Enable syntax highlighting and copy buttons on code blocks with Prism


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #435` or `Fixes #435` to link your PR with the issue. #435 stands for the issue number you are fixing -->

## Changes proposed

Manual changes to reflect the latest Hyperfoil https://github.com/Hyperfoil/Hyperfoil/releases/tag/hyperfoil-all-0.28.0 release in the documentation

## Check List (check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.

> Note that the documentation is located at [github.com/Hyperfoil/hyperfoil.github.io](https://github.com/Hyperfoil/hyperfoil.github.io/) 

<details>
<summary>
How to backport a pull request to the current <em>stable</em> branch?
</summary>

In order to automatically create a **backporting pull request** please add `backport` label to the current pull request.

Then, as soon as the pull request is merged into the `master` branch, the process will try to automatically open a backporting pull request against the _stable_ branch. If something goes wrong, a comment will be added in the original pull request such that all people involved get notified.

> The `backport` label can be also added after the pull  request has been merged.

> If the process fails due to temporary problems, such as connectivity problems, consider removing and re-adding the `backport` label.
</details>