### PR TITLE
Add wrk2 edge test scenarios

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/statistics/SessionStatistics.java
+++ b/api/src/main/java/io/hyperfoil/api/statistics/SessionStatistics.java
@@ -133,6 +133,11 @@ public class SessionStatistics {
 
    @Override
    public String toString() {
-      return "SessionStatistics{phases=" + Arrays.toString(phases) + '}';
+      // null add noise to the log
+      Phase[] newPhase = new Phase[size];
+      for (int i = 0; i < size; ++i) {
+         newPhase[i] = phases[i];
+      }
+      return "SessionStatistics{phases=" + Arrays.toString(newPhase) + '}';
    }
 }

--- a/core/src/main/java/io/hyperfoil/core/impl/statistics/StatisticsCollector.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/statistics/StatisticsCollector.java
@@ -29,8 +29,8 @@ public class StatisticsCollector implements Consumer<SessionStatistics> {
 
    @Override
    public void accept(SessionStatistics statistics) {
-      if (log.isDebugEnabled()) {
-         log.debug("{}: Received statistics", statistics);
+      if (log.isTraceEnabled()) {
+         log.trace("Received statistics for: {}", statistics);
       }
       for (int i = 0; i < statistics.size(); ++i) {
          int phaseAndStepId = (statistics.phase(i).id() << 16) + statistics.step(i);
@@ -39,7 +39,7 @@ public class StatisticsCollector implements Consumer<SessionStatistics> {
          if (metricMap == null) {
             metricMap = new HashMap<>();
             if (log.isDebugEnabled()) {
-               log.debug("{}: Aggregated metric statistics for phaseAndStepId={}", statistics, phaseAndStepId);
+               log.debug("Aggregated metric statistics for phaseAndStepId={} with values={}", phaseAndStepId, metricMap);
             }
             aggregated.put(phaseAndStepId, metricMap);
          }

--- a/http/src/main/java/io/hyperfoil/http/connection/Http1xConnection.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/Http1xConnection.java
@@ -212,8 +212,8 @@ class Http1xConnection extends ChannelDuplexHandler implements HttpConnection {
          // Note: the pool might be already released if the completion handler
          // invoked another request which was served from cache.
          boolean becameAvailable = inFlight() == pipeliningLimit - 1 && !isClosed();
-         if (log.isDebugEnabled()) {
-            log.debug("releasePoolAndPulse: {} inFlight={}, becameAvailable={}", this, inFlight(), becameAvailable);
+         if (log.isTraceEnabled()) {
+            log.trace("releasePoolAndPulse: {} inFlight={}, becameAvailable={}", this, inFlight(), becameAvailable);
          }
          pool.release(this, becameAvailable, true);
          pool.pulse();

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -96,8 +96,8 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
                   usedConnections.incrementUsed();
                }
                connection.onAcquire();
-               if (log.isDebugEnabled()) {
-                  log.debug("acquireNow: acquired {} to {}, inFlight={} (after), connection.inFlight={}",
+               if (log.isTraceEnabled()) {
+                  log.trace("acquireNow: acquired {} to {}, inFlight={} (after), connection.inFlight={}",
                         connection, authority, inFlight.current(), connection.inFlight());
                }
                return connection;
@@ -116,8 +116,8 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
 
    @Override
    public void acquire(boolean exclusiveConnection, ConnectionConsumer consumer) {
-      if (log.isDebugEnabled()) {
-         log.debug("acquire: {} exclusiveConnection={}, waiting={}, available={}, inFlight={}",
+      if (log.isTraceEnabled()) {
+         log.trace("acquire: {} exclusiveConnection={}, waiting={}, available={}, inFlight={}",
                authority, exclusiveConnection, waiting.size(), available.size(), inFlight.current());
       }
       HttpConnection connection = acquireNow(exclusiveConnection);
@@ -155,9 +155,9 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
       if (trace) {
          log.trace("Release {} (became available={} after request={})", connection, becameAvailable, afterRequest);
       }
-      if (log.isDebugEnabled()) {
+      if (log.isTraceEnabled()) {
          boolean alreadyInAvailable = available.contains(connection);
-         log.debug(
+         log.trace(
                "release: {} becameAvailable={}, afterRequest={}, connection.inFlight={}, inFlight={} (before), available={}, alreadyInAvailable={}",
                connection, becameAvailable, afterRequest, connection.inFlight(), inFlight.current(), available.size(),
                alreadyInAvailable);
@@ -231,8 +231,8 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
       if (trace) {
          log.trace("Pulse to {} ({} waiting)", authority, waiting.size());
       }
-      if (log.isDebugEnabled()) {
-         log.debug("pulse: {} shouldPulse={}, waiting={}, available={}, inFlight={}",
+      if (log.isTraceEnabled()) {
+         log.trace("pulse: {} shouldPulse={}, waiting={}, available={}, inFlight={}",
                authority, shouldPulse, waiting.size(), available.size(), inFlight.current());
       }
       // session terminated, there is nothing that we can do
@@ -387,8 +387,10 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
          // stop trying to create new connections and the sessions would be stuck.
          failures = 0;
          available.add(conn);
-         log.debug("Created {} to {} ({}+{}=?{}:{}/{})", conn, authority,
-               created, connecting, connections.size(), available.size() - availableClosed, sizeConfig.max());
+         if (log.isTraceEnabled()) {
+            log.trace("Created {} to {} ({}+{}=?{}:{}/{})", conn, authority,
+                  created, connecting, connections.size(), available.size() - availableClosed, sizeConfig.max());
+         }
 
          incrementTypeStats(conn);
 
@@ -467,8 +469,8 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
          executor().execute(this::onSessionTryTerminate);
          return;
       }
-      if (log.isDebugEnabled()) {
-         log.debug("onSessionTryTerminate: {} inFlight={}, available={}, waiting={}",
+      if (log.isTraceEnabled()) {
+         log.trace("onSessionTryTerminate: {} inFlight={}, available={}, waiting={}",
                authority, inFlight.current(), available.size(), waiting.size());
       }
       this.shouldPulse = false;

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/BaseWrkBenchmarkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/BaseWrkBenchmarkTest.java
@@ -1,6 +1,7 @@
 package io.hyperfoil.benchmark;
 
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
@@ -14,9 +15,22 @@ public abstract class BaseWrkBenchmarkTest extends BaseBenchmarkTest {
    private final long unservedDelay = 100;
    private final double servedRatio = 0.9;
 
+   protected AtomicInteger localStatsReceivedRequests = new AtomicInteger();
+   protected AtomicInteger localStatsReceivedResponses = new AtomicInteger();
+
    @Override
    protected final Handler<HttpServerRequest> getRequestHandler() {
       Router router = Router.router(vertx);
+
+      // global interceptor
+      router.route().handler(ctx -> {
+         localStatsReceivedRequests.getAndIncrement();
+         // callback
+         ctx.response().bodyEndHandler(v -> localStatsReceivedResponses.getAndIncrement());
+         // forward
+         ctx.next();
+      });
+
       router.route("/10s").handler(ctx -> {
          ctx.vertx().setTimer(10_000, id -> {
             ctx.response().end("10s");

--- a/test-suite/src/test/java/io/hyperfoil/scenario/WrkScenarioTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/scenario/WrkScenarioTest.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.hyperfoil.api.config.BenchmarkBuilder;
@@ -31,7 +32,24 @@ import io.hyperfoil.http.steps.HttpStepCatalog;
 
 public class WrkScenarioTest extends BaseWrkBenchmarkTest {
 
-   protected final Logger log = LogManager.getLogger(getClass());
+   private final Logger log = LogManager.getLogger(getClass());
+
+   @Test
+   @Disabled("Issue #626: wrk2 fail with high load - scenario where timeout is 2s")
+   // This test can be flaky if Hyperfoil is in a state where calibration phase is able to release the connections back to the pool
+   // The current configuration with TRACE logs enabled slow down a lot Hyperfoil
+   public void wrk2Test() throws URISyntaxException {
+      String url = "localhost:" + httpServer.actualPort() + "/500ms";
+
+      BaseScenarioTest.TestStatistics statisticsConsumer = runWrk2Scenario(6, 20, url, 50000, 2, 10, 1);
+
+      System.out.println(localStatsReceivedRequests.get());
+      System.out.println(localStatsReceivedResponses.get());
+
+      Assertions.assertTrue(statisticsConsumer.stats().containsKey("calibration"),
+            "Stats must have values for the 'calibration' phase");
+      Assertions.assertTrue(statisticsConsumer.stats().containsKey("test"), "Stats must have values for the 'test' phase");
+   }
 
    @Test
    public void wrk2SuperSlowServer() throws URISyntaxException {

--- a/test-suite/src/test/resources/log4j2.xml
+++ b/test-suite/src/test/resources/log4j2.xml
@@ -12,14 +12,14 @@
     </Appenders>
 
     <Loggers>
-        <Logger name="io.hyperfoil" level="TRACE"/>
+        <Logger name="io.hyperfoil" level="DEBUG"/>
         <Logger name="org.jgroups" level="TRACE"/>
         <Logger name="org.infinispan" level="INFO"/>
         <Logger name="io.vertx" level="INFO"/>
         <Logger name="io.netty" level="INFO"/>
 
         <Root level="INFO">
-            <AppenderRef ref="STDOUT" level="INFO"/>
+            <AppenderRef ref="STDOUT" level="DEBUG"/>
 
             <AppenderRef ref="FILE" level="TRACE"/>
         </Root>


### PR DESCRIPTION
The goal of this test is to demonstrate two scenarios that are failing:
* https://github.com/Hyperfoil/Hyperfoil/issues/638
* https://github.com/Hyperfoil/Hyperfoil/issues/626

During the test we have the following log
```
16:34:51,699 INFO  (main) [i.h.s.WrkScenarioTest] Test duration: 49s
16:34:51,700 INFO  (main) [i.h.s.WrkScenarioTest] --- phase: calibration ---
16:34:51,703 INFO  (main) [i.h.s.WrkScenarioTest] StatusHistory{previousStatus=NOT_STARTED, currentStatus=RUNNING, when=2025-12-22T16:34:14.995-03:00[America/Sao_Paulo], threadId=1}
16:34:51,704 INFO  (main) [i.h.s.WrkScenarioTest] 2025-12-22T16:34:20.995-03:00[America/Sao_Paulo] elapsed: 6s -> StatusHistory{previousStatus=RUNNING, currentStatus=FINISHED, when=2025-12-22T16:34:20.995-03:00[America/Sao_Paulo], threadId=1}
16:34:51,704 INFO  (main) [i.h.s.WrkScenarioTest] 2025-12-22T16:34:22.995-03:00[America/Sao_Paulo] elapsed: 2s -> StatusHistory{previousStatus=FINISHED, currentStatus=TERMINATING, when=2025-12-22T16:34:22.995-03:00[America/Sao_Paulo], threadId=1}
16:34:51,704 INFO  (main) [i.h.s.WrkScenarioTest] 2025-12-22T16:34:33.909-03:00[America/Sao_Paulo] elapsed: 10s -> StatusHistory{previousStatus=TERMINATING, currentStatus=TERMINATED, when=2025-12-22T16:34:33.909-03:00[America/Sao_Paulo], threadId=56}
16:34:51,704 INFO  (main) [i.h.s.WrkScenarioTest] 2025-12-22T16:34:33.917-03:00[America/Sao_Paulo] elapsed: 0s -> StatusHistory{previousStatus=TERMINATED, currentStatus=STATS_COMPLETE, when=2025-12-22T16:34:33.917-03:00[America/Sao_Paulo], threadId=56}
16:34:51,704 INFO  (main) [i.h.s.WrkScenarioTest] --- phase: test ---
16:34:51,705 INFO  (main) [i.h.s.WrkScenarioTest] StatusHistory{previousStatus=NOT_STARTED, currentStatus=RUNNING, when=2025-12-22T16:34:33.917-03:00[America/Sao_Paulo], threadId=1}
16:34:51,705 INFO  (main) [i.h.s.WrkScenarioTest] 2025-12-22T16:34:43.917-03:00[America/Sao_Paulo] elapsed: 10s -> StatusHistory{previousStatus=RUNNING, currentStatus=FINISHED, when=2025-12-22T16:34:43.917-03:00[America/Sao_Paulo], threadId=1}
16:34:51,705 INFO  (main) [i.h.s.WrkScenarioTest] 2025-12-22T16:34:43.917-03:00[America/Sao_Paulo] elapsed: 0s -> StatusHistory{previousStatus=FINISHED, currentStatus=TERMINATING, when=2025-12-22T16:34:43.917-03:00[America/Sao_Paulo], threadId=1}
16:34:51,705 INFO  (main) [i.h.s.WrkScenarioTest] 2025-12-22T16:34:51.450-03:00[America/Sao_Paulo] elapsed: 7s -> StatusHistory{previousStatus=TERMINATING, currentStatus=TERMINATED, when=2025-12-22T16:34:51.450-03:00[America/Sao_Paulo], threadId=55}
16:34:51,705 INFO  (main) [i.h.s.WrkScenarioTest] 2025-12-22T16:34:51.450-03:00[America/Sao_Paulo] elapsed: 0s -> StatusHistory{previousStatus=TERMINATED, currentStatus=STATS_COMPLETE, when=2025-12-22T16:34:51.450-03:00[America/Sao_Paulo], threadId=55}
```

Between FINISHED and TERMINATED, What should we do with `in-flight` requests?

