### PR TITLE
Add Maven Shade Plugin for wrk and wrk2 CLI executables

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -177,6 +177,53 @@
                     </arguments>
                 </configuration>
             </plugin>
+
+            <!--
+            The CLI jar is located in hyperfoil-clustering due to: https://github.com/Hyperfoil/Hyperfoil/issues/639
+
+            This placement enables testing external projects with Hyperfoil snapshot versions by simply
+            replacing "jbang wrk@hyperfoil" with "java -jar clustering/target/wrk.jar"
+
+            Example workflow: Share a branch → Build locally → Replace the command → Test results
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>wrk</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>wrk</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.hyperfoil.cli.commands.Wrk</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>wrk2</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>wrk2</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.hyperfoil.cli.commands.Wrk2</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Add Maven Shade Plugin for wrk and wrk2 CLI executables

How to test
```
mvn clean install -DskipTests -pl '!distribution'

java -jar clustering/target/wrk.jar -c 1 -d 1 www.google.com
Running 1 test @ http://www.google.com
  2 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   120.39ms    5.63ms 130.02ms   66.67%
    Req/Sec     9.00      0.00     9.00    100.00
  9 requests in 1.003s, 441.10kB read
Requests/sec: 8.97
Transfer/sec: 439.78kB

java -jar clustering/target/wrk2.jar -c 1 -d 1 --rate 1 www.google.com
Running 1 test @ http://www.google.com
  2 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   116.13ms       0ns 116.39ms    0.00%
    Req/Sec     1.00      0.00     1.00    100.00
  2 requests in 1.003s,  55.16kB read
Requests/sec: 1.99
Transfer/sec:  54.99kB
```