### PR TITLE
Ensures all statistics are properly collected and sent before phase completion by synchronizing event bus operations on the event loop thread

### DIFF
--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
@@ -30,8 +30,16 @@ public class WrkTest extends BaseWrkBenchmarkTest {
    public void testWrk() {
       Wrk cmd = new Wrk();
       int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "--latency", "--timeout", "1s",
-            "localhost:" + httpServer.actualPort() + "/unpredictable" });
+            "localhost:" + httpServer.actualPort() + "/highway" });
       assertEquals(CommandResult.SUCCESS.getResultValue(), result);
+   }
+
+   @Test
+   public void testWrkUnpredictable() {
+      Wrk cmd = new Wrk();
+      int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "--latency", "--timeout", "1s",
+            "localhost:" + httpServer.actualPort() + "/unpredictable" });
+      assertEquals(CommandResult.FAILURE.getResultValue(), result);
    }
 
    @Test
@@ -44,6 +52,14 @@ public class WrkTest extends BaseWrkBenchmarkTest {
 
    @Test
    public void testWrk2() {
+      Wrk2 cmd = new Wrk2();
+      int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "-R", "20", "--latency", "--timeout", "1s",
+            "localhost:" + httpServer.actualPort() + "/highway" });
+      assertEquals(CommandResult.SUCCESS.getResultValue(), result);
+   }
+
+   @Test
+   public void testWrk2Unpredictable() {
       Wrk2 cmd = new Wrk2();
       int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "-R", "20", "--latency", "--timeout", "1s",
             "localhost:" + httpServer.actualPort() + "/unpredictable" });
@@ -78,6 +94,26 @@ public class WrkTest extends BaseWrkBenchmarkTest {
       assertFalse(wrkCommandResult.getRequestStatisticsResponse().statistics.isEmpty());
       for (RequestStats requestStats : wrkCommandResult.getRequestStatisticsResponse().statistics) {
          assertTrue(requestStats.failedSLAs.isEmpty());
+      }
+   }
+
+   @Test
+   public void testWrk2HighLoad() throws CommandNotFoundException {
+      Wrk2 cmd = new Wrk2();
+      int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "-R", "20000", "--latency", "--timeout", "1s",
+            "localhost:" + httpServer.actualPort() + "/unpredictable" });
+
+      // Due to the nature of instances being created in runtime the only way to retrieve is by using the commandRegistry
+      CommandContainer<HyperfoilCommandInvocation> commandContainer = cmd.getCommandRegistry().getCommand("wrk2", null);
+      ProcessedCommand processedCommand = commandContainer.getParser().getProcessedCommand();
+      Wrk2.Wrk2Command wrk2Command = (Wrk2.Wrk2Command) processedCommand.getCommand();
+      WrkAbstract.WrkCommandResult wrkCommandResult = wrk2Command.getWrkCommandResult();
+
+      // assert
+      assertEquals(CommandResult.FAILURE.getResultValue(), result);
+      assertFalse(wrkCommandResult.getRequestStatisticsResponse().statistics.isEmpty());
+      for (RequestStats requestStats : wrkCommandResult.getRequestStatisticsResponse().statistics) {
+         assertFalse(requestStats.failedSLAs.isEmpty());
       }
    }
 }


### PR DESCRIPTION
Fix: https://github.com/Hyperfoil/Hyperfoil/issues/649

## Changes
Ensures all statistics are properly collected and sent before phase completion by synchronizing event bus operations on the event loop thread.

- Modified AgentVerticle to run all phase termination operations sequentially
  on the event loop thread, preventing race conditions between statistics
  collection and phase change notifications
- Changed phase change response from fire-and-forget to request-reply pattern
  to ensure proper completion ordering
- Added test case to ensure SLA validation

## Logs
As you can see, in the log before the fix, we have the entry `Phase test failed, cancelling other phases`, but the next phase is not canceled because there is a race condition explained above

**Before the fix**
```
20:58:27,938 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Starting in directory /tmp/hyperfoil...
20:58:29,295 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Starting benchmark wrk2 - run 002F
20:58:37,192 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 002F: completing stats for phase calibration
20:58:37,200 WARN  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Failed verify SLA(s) for calibration/request: Progress was blocked waiting for a free connection. Hint: increase http.sharedConnections.
20:58:37,200 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] SLA validation failed for calibration
20:58:37,201 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Phase calibration failed, cancelling other phases...
20:58:57,188 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] 002F Failing phase due to exceeded session limit.
20:58:57,188 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Phase test failed, cancelling other phases...
20:58:57,890 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Phase test failed, cancelling other phases...
20:58:57,890 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] 002F All phases are terminated.
20:58:57,892 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 002F: completing stats for phase test
20:58:57,895 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] SLA validation failed for test
20:58:57,895 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Phase test failed, cancelling other phases...
20:58:57,895 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 002F: stats for phase test are already completed, ignoring.
20:58:57,895 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 002F: stats for phase calibration are already completed, ignoring.
20:58:57,935 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 002F completed
20:58:58,017 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Successfully persisted run 002F
```

**After the fix**
```
20:59:57,326 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Starting in directory /tmp/hyperfoil...
20:59:58,681 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Starting benchmark wrk2 - run 0030
21:00:06,621 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 0030: completing stats for phase calibration
21:00:06,631 WARN  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Failed verify SLA(s) for calibration/request: Progress was blocked waiting for a free connection. Hint: increase http.sharedConnections.
21:00:06,631 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] SLA validation failed for calibration
21:00:06,631 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Phase calibration failed, cancelling other phases...
21:00:06,632 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Phase calibration failed, cancelling other phases...
21:00:06,632 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] 0030 All phases are terminated.
21:00:06,634 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 0030: completing stats for phase test
21:00:06,634 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] SLA validation failed for test
21:00:06,634 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Phase test failed, cancelling other phases...
21:00:06,634 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 0030: completing stats for phase calibration
21:00:06,643 WARN  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Failed verify SLA(s) for calibration/request: Progress was blocked waiting for a free connection. Hint: increase http.sharedConnections.
21:00:06,643 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] SLA validation failed for calibration
21:00:06,643 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Phase calibration failed, cancelling other phases...
21:00:06,684 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Run 0030 completed
21:00:06,753 INFO  (vert.x-eventloop-thread-0) [i.h.c.ControllerVerticle] Successfully persisted run 0030
```