### PR TITLE
Print total stats summary after run completes in LoadAndRun

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/Table.java
+++ b/cli/src/main/java/io/hyperfoil/cli/Table.java
@@ -179,7 +179,14 @@ public class Table<T> {
       int suffixLength = prefixes == null ? 0
             : prefixes.stream().filter(Objects::nonNull).mapToInt(Table::width).max().orElse(0);
       int totalWidth = IntStream.of(width).map(w -> w + 2).sum() - 2;
-      int maxWidth = invocation.getShell().size().getWidth() - prefixLength - suffixLength;
+      int shellWidth = invocation.getShell().size().getWidth();
+      if (shellWidth < totalWidth) {
+         int termWidth = org.aesh.readline.util.TerminalUtil.terminalWidth();
+         if (termWidth > shellWidth) {
+            shellWidth = termWidth;
+         }
+      }
+      int maxWidth = shellWidth - prefixLength - suffixLength;
       boolean multiline = totalWidth > maxWidth;
       int idsWidth = IntStream.of(width).limit(idColumns).map(w -> w + 2).sum();
       int stride = width.length - idColumns;

--- a/cli/src/main/java/io/hyperfoil/cli/commands/LoadAndRun.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/LoadAndRun.java
@@ -25,7 +25,7 @@ public class LoadAndRun extends BaseStandaloneCommand {
 
    @Override
    protected List<Class<? extends Command<HyperfoilCommandInvocation>>> getDependencyCommands() {
-      return List.of(Upload.class, Wait.class, Report.class);
+      return List.of(Upload.class, Wait.class, Stats.class, Report.class);
    }
 
    @Override
@@ -57,6 +57,7 @@ public class LoadAndRun extends BaseStandaloneCommand {
       @Override
       protected void monitor(HyperfoilCommandInvocation invocation) throws CommandException {
          invocation.executeSwitchable("wait");
+         invocation.executeSwitchable("stats -t");
          if (output != null && !output.isBlank()) {
             invocation.executeSwitchable("report --silent -y --destination " + output);
          } else {


### PR DESCRIPTION
Addresses jbang-catalog#14 by executing "stats -t" after the wait command completes, so that run@hyperfoil displays the same statistics table (PHASE, METRIC, THROUGHPUT, etc.) that cli@hyperfoil shows.

