### PR TITLE
[0.29.x] Release notes 0.29.0 and update hugo.yaml

### DIFF
--- a/docs/site/content/en/blog/releases/release_notes.md
+++ b/docs/site/content/en/blog/releases/release_notes.md
@@ -5,6 +5,23 @@ type: docs
 weight: 1
 ---
 
+## 0.29.0 (2026-04-16)
+
+* Nanosecond granularity for load generators, enabling sub-millisecond rate generation
+* Fix internal coordinated omission for open model phases
+* Fix open model catch-up sessions clustering on a single event loop (issue #627)
+* CLI and run commands packaged as standalone jar files via Maven Shade Plugin
+* Added warmupDuration option for wrk/wrk2 phases
+* Added version information to Agent and Controller
+* Print total stats summary after run completes in LoadAndRun
+* Refactored phase lifecycle and statistics collection for improved reliability
+* Ensured all statistics are properly collected and sent before phase completion
+* Resolved CpuWatchdog false positives due to tick rate assumptions
+* Disabled Netty leak detection by default
+* Updated the Hyperfoil report template
+* Added JDK 25 to the build matrix
+* Dependency upgrades, including HdrHistogram 2.2.2, JUnit 6, aesh 3.4, and various Maven plugins
+
 ## 0.28.0 (2025-10-01)
 
 * Upgraded to JDK 21

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -121,16 +121,16 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: 0.28.0
-  
+  version: 0.29.0
+
   # Uncomment this if your GitHub repo does not have "main" as the default branch,
   # or specify a new value if you want to reference another branch in your GitHub links
-  github_branch: 0.28.x
-  
+  github_branch: 0.29.x
+
   # Custom param: latest distribution url
 
-  url_latest_distribution: https://github.com/Hyperfoil/Hyperfoil/releases/download/hyperfoil-all-0.28.0/hyperfoil-0.28.0.zip
-  zip_latest_distribution: hyperfoil-0.28.0.zip
+  url_latest_distribution: https://github.com/Hyperfoil/Hyperfoil/releases/download/hyperfoil-all-0.29.0/hyperfoil-0.29.0.zip
+  zip_latest_distribution: hyperfoil-0.29.0.zip
   url_all_releases: https://github.com/Hyperfoil/Hyperfoil/releases/
 
   # Enable syntax highlighting and copy buttons on code blocks with Prism


### PR DESCRIPTION
**Backport:** https://github.com/Hyperfoil/Hyperfoil/pull/752

Once done merging this, we have to:
1. merge the auto-created backport PR to 0.29.x
2. submit a one-line PR to Hyperfoil/Hyperfoil.github.io changing ref: '0.28.x' → ref: '0.29.x' in `.github/workflows/deploy-gh-pages.yaml`