### PR TITLE
Preserve dependency POM for clustering shade plugin

### DIFF
--- a/clustering/pom.xml
+++ b/clustering/pom.xml
@@ -200,6 +200,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <id>wrk</id>


### PR DESCRIPTION
The Maven Shade Plugin generates a dependency-reduced-pom.xml that strips all shaded (compile-scope) dependencies, and publishes that instead of the original POM. The 0.29.0 release published a clustering POM with zero compile deps.

I has been verified via these steps:
1. Applied the fix: added <createDependencyReducedPom>false</createDependencyReducedPom> to the shade plugin in clustering/pom.xml                                    
  2. Built Hyperfoil: mvn install -pl clustering -am -DskipTests -Dmaven.compiler.proc=full (installs 0.30-SNAPSHOT to local .m2)
  3. Copied the original jbang-catalog.json from the jbang-catalog repo into the Hyperfoil folder, changed 0.29.0 → 0.30-SNAPSHOT so it resolves from the local build   
  4. Ran jbang --fresh wrk2@. --version from the Hyperfoil folder — it launched without the NoClassDefFoundError