### PR TITLE
Clustering module must use the Infinispan version from Vert.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
       NO_DOWNLOAD_MESSAGE: "-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
       QUAY_BOT_LOGIN: ${{secrets.QUAY_BOT_LOGIN}}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         java: [21, 26]

--- a/clustering/src/main/java/io/hyperfoil/Hyperfoil.java
+++ b/clustering/src/main/java/io/hyperfoil/Hyperfoil.java
@@ -4,10 +4,10 @@ import static io.hyperfoil.internal.Properties.CLUSTER_JGROUPS_STACK;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.BitSet;
@@ -20,13 +20,10 @@ import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.FormattedMessage;
-import org.infinispan.commons.dataconversion.MediaType;
 import org.infinispan.commons.util.FileLookupFactory;
 import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
 import org.infinispan.configuration.parsing.ParserRegistry;
-import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.manager.DefaultCacheManager;
-import org.infinispan.remoting.transport.Transport;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.jgroups.JChannel;
 import org.jgroups.protocols.TP;
@@ -127,7 +124,7 @@ public class Hyperfoil {
    }
 
    private static void populateProperties(DefaultCacheManager dcm) {
-      JGroupsTransport transport = (JGroupsTransport) GlobalComponentRegistry.componentOf(dcm, Transport.class);
+      JGroupsTransport transport = (JGroupsTransport) dcm.getCacheManagerConfiguration().transport().transport();
       JChannel channel = transport.getChannel();
       TP tp = channel.getProtocolStack().getTransport();
       System.setProperty(Properties.CONTROLLER_CLUSTER_IP, tp.getBindAddress().getHostAddress());
@@ -173,15 +170,20 @@ public class Hyperfoil {
    }
 
    private static DefaultCacheManager createCacheManager() {
-      try (InputStream stream = FileLookupFactory.newInstance().lookupFile("infinispan.xml",
-            Thread.currentThread().getContextClassLoader())) {
-         ConfigurationBuilderHolder holder = new ParserRegistry().parse(stream, MediaType.APPLICATION_XML);
+      try {
+         String configFile = "infinispan.xml";
+         URL url = FileLookupFactory.newInstance().lookupFileLocation(configFile,
+               Thread.currentThread().getContextClassLoader());
+         if (url == null) {
+            throw new IOException("Cannot find " + configFile);
+         }
+         ConfigurationBuilderHolder holder = new ParserRegistry().parse(url);
          holder.getGlobalConfigurationBuilder().transport().defaultTransport()
                .withProperties(System.getProperties())
                .initialClusterSize(1);
          return new DefaultCacheManager(holder, true);
       } catch (IOException e) {
-         log.error("Cannot load Infinispan configuration");
+         log.error("Cannot load Infinispan configuration", e);
          System.exit(1);
          return null;
       }

--- a/clustering/src/main/resources/infinispan.xml
+++ b/clustering/src/main/resources/infinispan.xml
@@ -15,8 +15,8 @@
   ~ under the License.
   -->
 <infinispan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xsi:schemaLocation="urn:infinispan:config:11.0 http://www.infinispan.org/schemas/infinispan-config-11.0.xsd urn:infinispan:config:clustered-locks:11.0 https://infinispan.org/schemas/infinispan-clustered-locks-config-11.0.xsd"
-            xmlns="urn:infinispan:config:11.0">
+            xsi:schemaLocation="urn:infinispan:config:13.0 http://www.infinispan.org/schemas/infinispan-config-13.0.xsd urn:infinispan:config:clustered-locks:13.0 https://infinispan.org/schemas/infinispan-clustered-locks-config-13.0.xsd"
+            xmlns="urn:infinispan:config:13.0">
 
     <jgroups>
         <stack-file name="jgroups" path="${io.hyperfoil.cluster.jgroups_stack:jgroups-tcp.xml}"/>
@@ -31,7 +31,7 @@
         <replicated-cache name="__vertx.haInfo"/>
         <replicated-cache name="__vertx.nodeInfo"/>
         <replicated-cache-configuration name="__vertx.distributed.cache.configuration"/>
-        <clustered-locks xmlns="urn:infinispan:config:clustered-locks:11.0"
+        <clustered-locks xmlns="urn:infinispan:config:clustered-locks:13.0"
                          reliability="AVAILABLE"/>
     </cache-container>
 

--- a/clustering/src/main/resources/jgroups-tcp-agent.xml
+++ b/clustering/src/main/resources/jgroups-tcp-agent.xml
@@ -3,22 +3,18 @@
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.0.xsd">
     <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address,io.hyperfoil.controller.cluster.ip:SITE_LOCAL}"
          bind_port="${jgroups.bind.port,jgroups.tcp.port,io.hyperfoil.controller.cluster.port:7800}"
-         diag.enabled="${jgroups.diag.enabled:false}"
+         enable_diagnostics="${jgroups.diag.enabled:false}"
          thread_naming_pattern="pl"
          send_buf_size="640k"
          sock_conn_timeout="300"
          tcp_nodelay="${jgroups.tcp.no_delay:true}"
          linger="${jgroups.tcp.linger:-1}"
          bundler_type="${jgroups.bundler.type:transfer-queue}"
-         bundler.max_size="${jgroups.bundler.max_size:64000}"
-         non_blocking_sends="${jgroups.non_blocking_sends:false}"
+         max_bundle_size="${jgroups.bundler.max_size:64000}"
 
          thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
          thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
          thread_pool.keep_alive_time="60000"
-
-         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
-         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:true}"
     />
     <RED/>
     <TCPPING send_cache_on_join="false" initial_hosts="${jgroups.tcpping.initial_hosts:}"/>
@@ -28,9 +24,8 @@
     <MERGE3 min_interval="1000"
             max_interval="3000"
     />
-    <FD_SOCK2 offset="${jgroups.fd.port-offset:50000}"/>
     <FD_ALL3/>
-    <VERIFY_SUSPECT2 timeout="1000"/>
+    <VERIFY_SUSPECT timeout="1000"/>
     <pbcast.NAKACK2 use_mcast_xmit="false"
                     xmit_interval="200"
                     xmit_table_num_rows="50"
@@ -56,5 +51,5 @@
     <MFC max_credits="${jgroups.max_credits:4m}"
          min_threshold="0.40"
     />
-    <FRAG4 frag_size="${jgroups.frag_size:60000}"/>
+    <FRAG3 frag_size="${jgroups.frag_size:60000}"/>
 </config>

--- a/clustering/src/main/resources/jgroups-tcp-agent.xml
+++ b/clustering/src/main/resources/jgroups-tcp-agent.xml
@@ -24,6 +24,7 @@
     <MERGE3 min_interval="1000"
             max_interval="3000"
     />
+    <FD_SOCK />
     <FD_ALL3/>
     <VERIFY_SUSPECT timeout="1000"/>
     <pbcast.NAKACK2 use_mcast_xmit="false"

--- a/clustering/src/main/resources/jgroups-tcp.xml
+++ b/clustering/src/main/resources/jgroups-tcp.xml
@@ -1,24 +1,19 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.0.xsd">
-    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address,io.hyperfoil.controller.cluster.ip:SITE_LOCAL}"
-         bind_port="${jgroups.bind.port,jgroups.tcp.port,io.hyperfoil.controller.cluster.port:7800}"
-         diag.enabled="${jgroups.diag.enabled:false}"
+    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
+         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
+         enable_diagnostics="${jgroups.diag.enabled:false}"
          thread_naming_pattern="pl"
          send_buf_size="640k"
          sock_conn_timeout="300"
-         tcp_nodelay="${jgroups.tcp.no_delay:true}"
          linger="${jgroups.tcp.linger:-1}"
          bundler_type="${jgroups.bundler.type:transfer-queue}"
-         bundler.max_size="${jgroups.bundler.max_size:64000}"
-         non_blocking_sends="${jgroups.non_blocking_sends:false}"
+         max_bundle_size="${jgroups.bundler.max_size:64000}"
 
          thread_pool.min_threads="${jgroups.thread_pool.min_threads:0}"
          thread_pool.max_threads="${jgroups.thread_pool.max_threads:200}"
          thread_pool.keep_alive_time="60000"
-
-         thread_pool.thread_dumps_threshold="${jgroups.thread_dumps_threshold:10000}"
-         use_virtual_threads="${jgroups.thread.virtual,org.infinispan.threads.virtual:true}"
     />
     <RED/>
     <TCPPING send_cache_on_join="true"/>
@@ -28,9 +23,8 @@
     <MERGE3 min_interval="1000"
             max_interval="3000"
     />
-    <FD_SOCK2 offset="${jgroups.fd.port-offset:50000}"/>
     <FD_ALL3/>
-    <VERIFY_SUSPECT2 timeout="1000"/>
+    <VERIFY_SUSPECT timeout="1000"/>
     <pbcast.NAKACK2 use_mcast_xmit="false"
                     xmit_interval="200"
                     xmit_table_num_rows="50"
@@ -47,12 +41,14 @@
     <pbcast.STABLE desired_avg_gossip="5000"
                    max_bytes="1M"
     />
-    <pbcast.GMS print_local_addr="false" join_timeout="0"/>
+    <pbcast.GMS print_local_addr="false"
+                join_timeout="${jgroups.join_timeout:2000}"
+    />
     <UFC max_credits="${jgroups.max_credits:4m}"
          min_threshold="0.40"
     />
     <MFC max_credits="${jgroups.max_credits:4m}"
          min_threshold="0.40"
     />
-    <FRAG4 frag_size="${jgroups.frag_size:60000}"/>
+    <FRAG3 frag_size="${jgroups.frag_size:60000}"/>
 </config>

--- a/clustering/src/main/resources/jgroups-tcp.xml
+++ b/clustering/src/main/resources/jgroups-tcp.xml
@@ -7,6 +7,7 @@
          thread_naming_pattern="pl"
          send_buf_size="640k"
          sock_conn_timeout="300"
+         tcp_nodelay="${jgroups.tcp.no_delay:true}"
          linger="${jgroups.tcp.linger:-1}"
          bundler_type="${jgroups.bundler.type:transfer-queue}"
          max_bundle_size="${jgroups.bundler.max_size:64000}"

--- a/clustering/src/main/resources/jgroups-tcp.xml
+++ b/clustering/src/main/resources/jgroups-tcp.xml
@@ -1,8 +1,8 @@
 <config xmlns="urn:org:jgroups"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups-4.0.xsd">
-    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address:SITE_LOCAL}"
-         bind_port="${jgroups.bind.port,jgroups.tcp.port:7800}"
+    <TCP bind_addr="${jgroups.bind.address,jgroups.tcp.address,io.hyperfoil.controller.cluster.ip:SITE_LOCAL}"
+         bind_port="${jgroups.bind.port,jgroups.tcp.port,io.hyperfoil.controller.cluster.port:7800}"
          enable_diagnostics="${jgroups.diag.enabled:false}"
          thread_naming_pattern="pl"
          send_buf_size="640k"
@@ -23,6 +23,7 @@
     <MERGE3 min_interval="1000"
             max_interval="3000"
     />
+    <FD_SOCK />
     <FD_ALL3/>
     <VERIFY_SUSPECT timeout="1000"/>
     <pbcast.NAKACK2 use_mcast_xmit="false"

--- a/hotrod/pom.xml
+++ b/hotrod/pom.xml
@@ -9,6 +9,48 @@
 
     <artifactId>hyperfoil-hotrod</artifactId>
     <name>Hyperfoil Hot Rod Client</name>
+    
+    <properties>
+        <!-- latest available version -->
+        <version.infinispan>16.0.10</version.infinispan>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-bom</artifactId>
+                <version>${version.infinispan}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- BOM doesn't manage test-jar classifiers, so we need to explicitly define them -->
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-server-hotrod</artifactId>
+                <version>${version.infinispan}</version>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-server-core</artifactId>
+                <version>${version.infinispan}</version>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-core</artifactId>
+                <version>${version.infinispan}</version>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-client-hotrod</artifactId>
+                <version>${version.infinispan}</version>
+                <type>test-jar</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -27,29 +69,7 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
-            <version>${version.infinispan}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.github.ben-manes.caffeine</groupId>
-                    <artifactId>caffeine</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.sshd</groupId>
-                    <artifactId>sshd-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.reactivex.rxjava3</groupId>
-                    <artifactId>rxjava</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.reactivex.rxjava2</groupId>
-                    <artifactId>rxjava</artifactId>
-                </exclusion>
-            </exclusions>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -57,6 +77,12 @@
             <artifactId>hyperfoil-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.vertx</groupId>
+                    <artifactId>vertx-infinispan</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -76,7 +102,6 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-hotrod</artifactId>
-            <version>${version.infinispan}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -88,14 +113,23 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-hotrod</artifactId>
-            <version>${version.infinispan}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-server-core</artifactId>
-            <version>${version.infinispan}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-server-core</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
             <exclusions>
@@ -108,7 +142,6 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
-            <version>${version.infinispan}</version>
             <scope>test</scope>
             <type>test-jar</type>
             <exclusions>
@@ -125,7 +158,6 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-client-hotrod</artifactId>
-            <version>${version.infinispan}</version>
             <type>test-jar</type>
             <scope>test</scope>
             <exclusions>
@@ -138,7 +170,6 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons-test</artifactId>
-            <version>${version.infinispan}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -154,6 +185,26 @@
                     <artifactId>rxjava</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-tasks</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-commons</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan.protostream</groupId>
+            <artifactId>protostream</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -196,6 +247,49 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.github.ben-manes.caffeine:*</include>
+                                    <include>org.infinispan:*</include>
+                                    <include>org.infinispan.protostream:*</include>
+                                    <include>org.wildfly.common:*</include>
+                                    <include>org.wildfly.security:*</include>
+                                    <include>jakarta.transaction:jakarta.transaction-api</include>
+                                    <include>io.reactivex.rxjava3:rxjava</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.infinispan</pattern>
+                                    <shadedPattern>shaded.org.infinispan</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>jakarta.transaction</pattern>
+                                    <shadedPattern>shaded.jakarta.transaction</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.reactivex.rxjava3</pattern>
+                                    <shadedPattern>shaded.io.reactivex.rxjava3</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
@@ -207,7 +301,7 @@
                         <configuration>
                             <skip>${module.skipCopyDependencies}</skip>
                             <includeScope>runtime</includeScope>
-                            <excludeGroupIds>com.github.ben-manes.caffeine,org.infinispan.protostream</excludeGroupIds>
+                            <excludeGroupIds>com.github.ben-manes.caffeine,org.infinispan,org.infinispan.protostream,org.wildfly,jakarta.transaction,io.reactivex.rxjava3</excludeGroupIds>
                             <silent>true</silent>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
         <version.slf4j>2.0.17</version.slf4j>
         <version.snakeyaml>2.6</version.snakeyaml>
         <version.vertx>4.5.21</version.vertx>
-        <version.infinispan>16.0.10</version.infinispan>
         <!-- begin: JBoss/WildFly/SmallRye dependency versions - these must be compatible with each other.
              jboss-threads 3.9.2 requires smallrye-common 2.14.0, which is newer than what
              wildfly-common 2.0.1 brings (smallrye 2.4.0). We explicitly manage smallrye-common versions
@@ -279,14 +278,6 @@
                 <groupId>io.vertx</groupId>
                 <artifactId>vertx-dependencies</artifactId>
                 <version>${version.vertx}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-bom</artifactId>
-                <version>${version.infinispan}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Clustering module must use the Infinispan version from Vert.x


## TL;DR - How It Works

### Shading Process

1. **Build Time**: Maven shade plugin:
   - Takes classes from Infinispan 16.0.10 and its dependencies
   - Rewrites package names (e.g., `org.infinispan` ? `shaded.org.infinispan`)
   - Embeds them into `hyperfoil-hotrod-0.30-SNAPSHOT.jar`

2. **Dependency Resolution**: The `<optional>true</optional>` flag:
   - Tells Maven these dependencies are only needed to build hotrod
   - Prevents them from being inherited as transitive dependencies
   - Stops Maven from copying separate JAR files to the distribution

### Result in Distribution

After building, the `distribution/target/hyperfoil-0.30-SNAPSHOT.zip` contains:

**In `lib/hyperfoil-hotrod-0.30-SNAPSHOT.jar`** (shaded):
```
shaded/org/infinispan/*                    (Infinispan 16.0.10)
shaded/jakarta/transaction/*               (jakarta.transaction-api 2.0.1)
shaded/io/reactivex/rxjava3/*             (rxjava 3.1.12)
```

**In `lib/` folder** (from clustering module):
```
infinispan-commons-13.0.17.Final.jar
infinispan-core-13.0.17.Final.jar
jakarta.transaction-api-1.3.3.jar
rxjava-3.0.13.jar
vertx-infinispan-4.5.21.jar
```

### No Conflicts

- **Hotrod** uses Infinispan 16.0.10 via shaded classes in `shaded.org.infinispan.*` package
- **Clustering** uses Infinispan 13.0.17 via original classes in `org.infinispan.*` package
- Both versions coexist without conflicts because they're in different package namespaces

## Verification Commands

```bash
# Extract distribution
cd distribution/target
unzip -q hyperfoil-0.30-SNAPSHOT.zip

# Check lib folder (should only have Infinispan 13.0.17)
ls -la hyperfoil-0.30-SNAPSHOT/lib/ | grep infinispan

# Verify shaded classes in hotrod JAR
jar tf hyperfoil-0.30-SNAPSHOT/lib/hyperfoil-hotrod-0.30-SNAPSHOT.jar | grep "^shaded/org/infinispan" | head -20
jar tf hyperfoil-0.30-SNAPSHOT/lib/hyperfoil-hotrod-0.30-SNAPSHOT.jar | grep "^shaded/jakarta/transaction" | head -10
jar tf hyperfoil-0.30-SNAPSHOT/lib/hyperfoil-hotrod-0.30-SNAPSHOT.jar | grep "^shaded/io/reactivex" | head -10
```

## Why Both Shading AND Optional Are Needed

### Common Misconception
"If we shade the dependencies, why do we need `<optional>true</optional>`?"

### The Answer

**Shade plugin** operates at the **bytecode/JAR level**:
- Physically relocates and embeds classes into the JAR file
- Works at build/package time

**Optional dependencies** operate at the **Maven POM level**:
- Controls Maven's dependency resolution and transitive dependency propagation
- Works at dependency resolution time

**Without optional:**
- Maven still sees `infinispan-client-hotrod:16.0.10` in hotrod's POM
- When distribution depends on hotrod, Maven tries to resolve it as a transitive dependency
- This creates the convergence conflict with clustering's Infinispan 13.0.17

**With optional:**
- Maven knows these dependencies are only needed to compile hotrod
- They won't propagate to modules that depend on hotrod
- The shaded classes are already in the JAR, so separate JARs aren't needed

This is the **standard Maven pattern** for shaded dependencies: shade them into your JAR AND mark them as optional to prevent transitive dependency pollution.

