### PR TITLE
Optimize SSH file transfer by batching uploads

### DIFF
--- a/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployedAgent.java
+++ b/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployedAgent.java
@@ -8,7 +8,9 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -166,20 +168,25 @@ public class SshDeployedAgent implements DeployedAgent {
       String java = Properties.get(Properties.AGENT_JAVA_EXECUTABLE, "java");
       startAgentCommmand.append(java).append(" -cp ");
 
+      List<String> fileToUpload = new ArrayList<>();
       for (Map.Entry<String, String> entry : localMd5.entrySet()) {
          int lastSlash = entry.getKey().lastIndexOf("/");
          String filename = lastSlash < 0 ? entry.getKey() : entry.getKey().substring(lastSlash + 1);
          String remoteChecksum = remoteMd5.remove(filename);
          if (!entry.getValue().equals(remoteChecksum)) {
             log.debug("MD5 mismatch {}/{}, copying {}", entry.getValue(), remoteChecksum, entry.getKey());
-            try {
-               scpClient.upload(entry.getKey(), dir + AGENTLIB + "/" + filename, ScpClient.Option.PreserveAttributes);
-            } catch (IOException e) {
-               exceptionHandler.accept(e);
-               return;
-            }
+            fileToUpload.add(entry.getKey());
          }
          startAgentCommmand.append(dir).append(AGENTLIB).append('/').append(filename).append(':');
+      }
+      if (!fileToUpload.isEmpty()) {
+         try {
+            scpClient.upload(fileToUpload.toArray(String[]::new), dir + AGENTLIB + "/",
+                  ScpClient.Option.PreserveAttributes);
+         } catch (IOException e) {
+            exceptionHandler.accept(e);
+            return;
+         }
       }
       if (!remoteMd5.isEmpty()) {
          StringBuilder rmCommand = new StringBuilder();

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/BaseWrkBenchmarkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/BaseWrkBenchmarkTest.java
@@ -11,7 +11,7 @@ import io.vertx.ext.web.Router;
  */
 public abstract class BaseWrkBenchmarkTest extends BaseBenchmarkTest {
 
-   private final long unservedDelay = 2000;
+   private final long unservedDelay = 100;
    private final double servedRatio = 0.9;
 
    @Override

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
@@ -73,8 +73,8 @@ public class WrkTest extends BaseWrkBenchmarkTest {
       Wrk2 cmd = new Wrk2();
       int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "-R", "20", "--latency", "--timeout", "1s", "--output",
             reportFile.toString(), "localhost:" + httpServer.actualPort() + "/unpredictable" });
-      assertEquals(CommandResult.SUCCESS.getResultValue(), result);
-      assertTrue(reportFile.toFile().exists());
+      assertEquals(CommandResult.SUCCESS.getResultValue(), result, "Wrk2 command should succeed.");
+      assertTrue(reportFile.toFile().exists(), "Expected HTML report file to be created at: " + reportFile);
    }
 
    @Test


### PR DESCRIPTION
Optimize SSH file transfer by batching uploads

This can boost the copy by around 10x
Here is the raw data and ratio.

| Files | scp (Baseline) | scp with array |
|---|---|---|
| 1 | 336 ms (1.0x) | 292 ms (1.15x faster) |
| 10 | 3235 ms (1.0x) | 533 ms (6.07x faster) |
| 100 | 33482 ms (1.0x) | 3243 ms (10.32x faster) |
| 1000 | 319168 ms (1.0x) | 32844 ms (9.72x faster) |

Reproducer. You need to remove the files because there is a checksum in the code to prevent copying again.
``` 
rm -fR /home/dlovison/.m2/repository/io/hyperfoil/hyperfoil-clustering
rm -fR /tmp/hyperfoil/
mvn clean package -Pbenchmark
``` 