### PR TITLE
Add configurable file transfer client with SCP/SFTP support

### DIFF
--- a/api/src/main/java/io/hyperfoil/internal/Properties.java
+++ b/api/src/main/java/io/hyperfoil/internal/Properties.java
@@ -42,6 +42,7 @@ public interface Properties {
    String CLUSTER_JGROUPS_STACK = "io.hyperfoil.cluster.jgroups_stack";
    String REPORT_TEMPLATE = "io.hyperfoil.report.template";
    String DISABLE_ENDPOINT_IDENTIFICATION = "io.hyperfoil.disable.endpoint.identification";
+   String FILE_TRANSFER_CLIENT = "io.hyperfoil.file.transfer.client";
 
    static String get(String property, String def) {
       return get(property, Function.identity(), def);

--- a/clustering/src/main/java/io/hyperfoil/deploy/ssh/FileTransfer.java
+++ b/clustering/src/main/java/io/hyperfoil/deploy/ssh/FileTransfer.java
@@ -1,0 +1,110 @@
+package io.hyperfoil.deploy.ssh;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.scp.client.ScpClient;
+import org.apache.sshd.scp.client.ScpClientCreator;
+import org.apache.sshd.sftp.client.SftpClient;
+import org.apache.sshd.sftp.client.SftpClientFactory;
+
+import io.hyperfoil.internal.Properties;
+
+public class FileTransfer implements AutoCloseable {
+
+   private static final Logger log = LogManager.getLogger(FileTransfer.class);
+
+   private IFileTransfer client;
+
+   FileTransfer(ClientSession session) throws Exception {
+      String fileTransferClient = Properties.get(Properties.FILE_TRANSFER_CLIENT, "scp");
+      log.info("Using {} protocol for file transfer", fileTransferClient);
+      if ("scp".equals(fileTransferClient)) {
+         this.client = new Scp(session);
+      } else if ("sftp".equals(fileTransferClient)) {
+         this.client = new Sftp(session);
+      } else {
+         throw new IllegalArgumentException("Invalid file transfer client. You provided: " + fileTransferClient);
+      }
+   }
+
+   public void upload(String local, String remote) throws IOException {
+      this.upload(List.of(local), remote);
+   }
+
+   public void upload(List<String> local, String remote) throws IOException {
+      this.client.upload(local, remote);
+   }
+
+   @Override
+   public void close() throws IOException {
+      this.client.close();
+   }
+
+   private interface IFileTransfer {
+
+      void upload(List<String> local, String remote) throws IOException;
+
+      void close() throws IOException;
+   }
+
+   private static class Scp implements IFileTransfer {
+
+      private ScpClient scpClient;
+
+      Scp(ClientSession session) {
+         this.scpClient = ScpClientCreator.instance().createScpClient(session);
+      }
+
+      @Override
+      public void upload(List<String> local, String remote) throws IOException {
+         if (!local.isEmpty()) {
+            this.scpClient.upload(local.toArray(String[]::new), remote, ScpClient.Option.PreserveAttributes);
+         }
+      }
+
+      @Override
+      public void close() {
+
+      }
+   }
+
+   private static class Sftp implements IFileTransfer {
+
+      private SftpClient sftpClient;
+
+      Sftp(ClientSession session) throws Exception {
+         try {
+            this.sftpClient = SftpClientFactory.instance().createSftpClient(session);
+         } catch (IOException e) {
+            throw new Exception("Problem while creating the Sftp instance", e);
+         }
+      }
+
+      @Override
+      public void upload(List<String> local, String remote) throws IOException {
+         for (String l : local) {
+            try (InputStream in = new FileInputStream(l);
+                  OutputStream out = sftpClient.write(remote + "/" + new File(l).getName())) {
+               byte[] buffer = new byte[8192];
+               int len;
+               while ((len = in.read(buffer)) != -1) {
+                  out.write(buffer, 0, len);
+               }
+            }
+         }
+      }
+
+      @Override
+      public void close() throws IOException {
+         this.sftpClient.close();
+      }
+   }
+}

--- a/clustering/src/main/java/io/hyperfoil/deploy/ssh/FileTransfer.java
+++ b/clustering/src/main/java/io/hyperfoil/deploy/ssh/FileTransfer.java
@@ -93,7 +93,7 @@ public class FileTransfer implements AutoCloseable {
          for (String l : local) {
             try (InputStream in = new FileInputStream(l);
                   OutputStream out = sftpClient.write(remote + "/" + new File(l).getName())) {
-               byte[] buffer = new byte[8192];
+               byte[] buffer = new byte[32768];
                int len;
                while ((len = in.read(buffer)) != -1) {
                   out.write(buffer, 0, len);

--- a/clustering/src/main/java/io/hyperfoil/deploy/ssh/FileTransfer.java
+++ b/clustering/src/main/java/io/hyperfoil/deploy/ssh/FileTransfer.java
@@ -19,16 +19,19 @@ import io.hyperfoil.internal.Properties;
 
 public class FileTransfer implements AutoCloseable {
 
+   public static final String PROTOCOL_SCP = "scp";
+   public static final String PROTOCOL_SFTP = "sftp";
+
    private static final Logger log = LogManager.getLogger(FileTransfer.class);
 
    private IFileTransfer client;
 
    FileTransfer(ClientSession session) throws Exception {
-      String fileTransferClient = Properties.get(Properties.FILE_TRANSFER_CLIENT, "scp");
+      String fileTransferClient = Properties.get(Properties.FILE_TRANSFER_CLIENT, PROTOCOL_SCP);
       log.info("Using {} protocol for file transfer", fileTransferClient);
-      if ("scp".equals(fileTransferClient)) {
+      if (PROTOCOL_SCP.equals(fileTransferClient)) {
          this.client = new Scp(session);
-      } else if ("sftp".equals(fileTransferClient)) {
+      } else if (PROTOCOL_SFTP.equals(fileTransferClient)) {
          this.client = new Sftp(session);
       } else {
          throw new IllegalArgumentException("Invalid file transfer client. You provided: " + fileTransferClient);
@@ -89,10 +92,25 @@ public class FileTransfer implements AutoCloseable {
       }
 
       @Override
-      public void upload(List<String> local, String remote) throws IOException {
-         for (String l : local) {
-            try (InputStream in = new FileInputStream(l);
-                  OutputStream out = sftpClient.write(remote + "/" + new File(l).getName())) {
+      public void upload(List<String> localFiles, String remote) throws IOException {
+         for (String localFile : localFiles) {
+
+            String localFileName = new File(localFile).getName();
+
+            String targetPath;
+            if (remote.endsWith(localFileName)) {
+               // Scenario 1: remote is already an exact file path (e.g., /dir/agentlib/log4j2.xml)
+               targetPath = remote;
+            } else if (remote.endsWith(File.separator)) {
+               // Scenario 2: remote is a directory path ending with a slash (e.g., /dir/agentlib/)
+               targetPath = remote + localFileName;
+            } else {
+               // Scenario 3: remote is a directory path without a trailing slash (e.g., /dir/agentlib)
+               targetPath = remote + File.separator + localFileName;
+            }
+
+            try (InputStream in = new FileInputStream(localFile);
+                  OutputStream out = sftpClient.write(targetPath)) {
                byte[] buffer = new byte[32768];
                int len;
                while ((len = in.read(buffer)) != -1) {

--- a/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployedAgent.java
+++ b/clustering/src/main/java/io/hyperfoil/deploy/ssh/SshDeployedAgent.java
@@ -25,8 +25,6 @@ import org.apache.sshd.common.io.IoOutputStream;
 import org.apache.sshd.common.io.IoReadFuture;
 import org.apache.sshd.common.util.buffer.ByteArrayBuffer;
 import org.apache.sshd.common.util.io.output.NullOutputStream;
-import org.apache.sshd.scp.client.ScpClient;
-import org.apache.sshd.scp.client.ScpClientCreator;
 import org.apache.sshd.sftp.client.SftpClient;
 import org.apache.sshd.sftp.client.SftpClientFactory;
 
@@ -58,7 +56,7 @@ public class SshDeployedAgent implements DeployedAgent {
    private ClientSession session;
    private ChannelShell shellChannel;
    private Consumer<Throwable> exceptionHandler;
-   private ScpClient scpClient;
+   private FileTransfer fileTransfer;
    private PrintStream commandStream;
 
    public SshDeployedAgent(String name, String runId, String username, String hostname, String sshKey, int port, String dir,
@@ -88,6 +86,11 @@ public class SshDeployedAgent implements DeployedAgent {
          log.error("Failed closing shell for agent: {}", name, e);
       }
       try {
+         this.fileTransfer.close();
+      } catch (IOException e) {
+         log.error("Failed closing the file transfer", e);
+      }
+      try {
          session.close();
       } catch (IOException e) {
          log.error("Failed closing SSH session for agent: {}", name, e);
@@ -97,9 +100,12 @@ public class SshDeployedAgent implements DeployedAgent {
    public void deploy(ClientSession session, Consumer<Throwable> exceptionHandler) {
       this.session = session;
       this.exceptionHandler = exceptionHandler;
-
-      this.scpClient = ScpClientCreator.instance().createScpClient(session);
-
+      try {
+         this.fileTransfer = new FileTransfer(session);
+      } catch (Exception e) {
+         exceptionHandler.accept(new DeploymentException("Failed to initialize file transfer", e));
+         return;
+      }
       try {
          this.shellChannel = session.createShellChannel();
          shellChannel.setStreaming(ClientChannel.Streaming.Async);
@@ -167,27 +173,31 @@ public class SshDeployedAgent implements DeployedAgent {
       }
       String java = Properties.get(Properties.AGENT_JAVA_EXECUTABLE, "java");
       startAgentCommmand.append(java).append(" -cp ");
-
-      List<String> fileToUpload = new ArrayList<>();
+      long startTime = System.currentTimeMillis();
+      List<String> filesToUpload = new ArrayList<>();
       for (Map.Entry<String, String> entry : localMd5.entrySet()) {
          int lastSlash = entry.getKey().lastIndexOf("/");
          String filename = lastSlash < 0 ? entry.getKey() : entry.getKey().substring(lastSlash + 1);
          String remoteChecksum = remoteMd5.remove(filename);
          if (!entry.getValue().equals(remoteChecksum)) {
-            log.debug("MD5 mismatch {}/{}, copying {}", entry.getValue(), remoteChecksum, entry.getKey());
-            fileToUpload.add(entry.getKey());
+            if (log.isDebugEnabled()) {
+               log.debug("MD5 mismatch {}/{}, copying {}", entry.getValue(), remoteChecksum, entry.getKey());
+               log.debug("Starting file transfer for {}", filename);
+            }
+            filesToUpload.add(entry.getKey());
          }
          startAgentCommmand.append(dir).append(AGENTLIB).append('/').append(filename).append(':');
       }
-      if (!fileToUpload.isEmpty()) {
-         try {
-            scpClient.upload(fileToUpload.toArray(String[]::new), dir + AGENTLIB + "/",
-                  ScpClient.Option.PreserveAttributes);
-         } catch (IOException e) {
-            exceptionHandler.accept(e);
-            return;
-         }
+
+      try {
+         fileTransfer.upload(filesToUpload, dir + AGENTLIB);
+      } catch (IOException e) {
+         exceptionHandler.accept(e);
+         return;
       }
+
+      long elapsed = System.currentTimeMillis() - startTime;
+      log.info("File transfer completed in {} ms", elapsed);
       if (!remoteMd5.isEmpty()) {
          StringBuilder rmCommand = new StringBuilder();
          // Drop those files that are not on classpath
@@ -205,7 +215,7 @@ public class SshDeployedAgent implements DeployedAgent {
          String filename = log4jConfigurationFile.substring(log4jConfigurationFile.lastIndexOf(File.separatorChar) + 1);
          try {
             String targetFile = dir + AGENTLIB + "/" + filename;
-            scpClient.upload(log4jConfigurationFile, targetFile, ScpClient.Option.PreserveAttributes);
+            fileTransfer.upload(log4jConfigurationFile, targetFile);
             startAgentCommmand.append(" -D").append(Properties.LOG4J2_CONFIGURATION_FILE)
                   .append("=file://").append(targetFile);
          } catch (IOException e) {

--- a/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferBaseTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferBaseTest.java
@@ -1,0 +1,74 @@
+package io.hyperfoil.deploy.ssh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.PropertyResolverUtils;
+import org.apache.sshd.core.CoreModuleProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+public class FileTransferBaseTest {
+
+   private static final Logger log = LogManager.getLogger(FileTransferBaseTest.class);
+
+   static final String TEST_HOST = System.getProperty("ssh.test.host", "localhost");
+   static final int TEST_PORT = Integer.parseInt(System.getProperty("ssh.test.port", "22"));
+   static final String TEST_USER = System.getProperty("ssh.test.user", System.getProperty("user.name"));
+
+   @TempDir
+   Path tempDir;
+
+   @TempDir
+   Path remoteDir;
+
+   SshClient client;
+   ClientSession session;
+
+   @BeforeEach
+   public void setup() throws Exception {
+      client = SshClient.setUpDefaultClient();
+      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.IDLE_TIMEOUT.getName(), Long.MAX_VALUE);
+      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.NIO2_READ_TIMEOUT.getName(), Long.MAX_VALUE);
+      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.NIO_WORKERS.getName(), 1);
+
+      client.start();
+      client.setServerKeyVerifier((clientSession, remoteAddress, serverKey) -> true);
+
+      // Connect and authenticate
+      session = client.connect(TEST_USER, TEST_HOST, TEST_PORT).verify(15000).getSession();
+      session.auth().verify(10000);
+   }
+
+   @AfterEach
+   public void teardown() throws Exception {
+      if (session != null) {
+         session.close();
+      }
+
+      if (client != null) {
+         client.stop();
+      }
+
+      cleanupFolder(tempDir);
+      cleanupFolder(remoteDir);
+   }
+
+   private void cleanupFolder(Path folder) throws IOException {
+      try (var files = Files.list(folder)) {
+         files.forEach(p -> {
+            try {
+               Files.deleteIfExists(p);
+            } catch (IOException e) {
+               log.warn("Failed to clean up {}", p, e);
+            }
+         });
+      }
+   }
+}

--- a/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferPerformanceTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferPerformanceTest.java
@@ -1,0 +1,141 @@
+package io.hyperfoil.deploy.ssh;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.hyperfoil.internal.Properties;
+
+/**
+ * Performance test for FileTransfer class from SshDeployedAgent.
+ * Tests the configured file transfer protocol (SCP or SFTP).
+ * <p>
+ * This test requires:
+ * 1. SSH server running on localhost:22
+ * 2. SSH key authentication configured (~/.ssh/id_rsa)
+ * <p>
+ * Set these system properties to configure the test:
+ * - ssh.test.host (default: localhost)
+ * - ssh.test.port (default: 22)
+ * - ssh.test.user (default: current user)
+ * - io.hyperfoil.file.transfer.client (default: scp) - set to "scp" or "sftp"
+ * <p>
+ * Example usage:
+ * mvn test -Dtest=FileTransferPerformanceTest -Dio.hyperfoil.file.transfer.client=scp
+ * mvn test -Dtest=FileTransferPerformanceTest -Dio.hyperfoil.file.transfer.client=sftp
+ */
+@Tag("io.hyperfoil.test.Benchmark")
+public class FileTransferPerformanceTest extends FileTransferBaseTest {
+
+   private static final Logger log = LogManager.getLogger(FileTransferPerformanceTest.class);
+
+   // Use fixed seed for reproducible results
+   static final long SEED = 42L;
+   static final int MIN_FILE_SIZE = 1024; // 1KB
+   static final int MAX_FILE_SIZE = 1024 * 1024; // 1MB
+
+   @Test
+   public void testFileTransferPerformance() throws Exception {
+      String protocol = System.getProperty(Properties.FILE_TRANSFER_CLIENT, "scp");
+
+      log.info("=== FileTransfer Performance Test ===");
+      log.info("Protocol: {}", protocol);
+      log.info("Host: {}@{}:{}", TEST_USER, TEST_HOST, TEST_PORT);
+      log.info("Remote directory: {}", remoteDir);
+      log.info("Seed: " + SEED);
+
+      int[] fileCounts = { 1, 10, 100, 1000 };
+
+      for (int fileCount : fileCounts) {
+         log.info("--- Testing with {} file(s) ---", fileCount);
+
+         // Generate test files
+         List<String> testFiles = generateTestFiles(fileCount);
+         long totalSize = 0;
+         for (String f : testFiles) {
+            totalSize += new File(f).length();
+         }
+         log.info(String.format("Total size: %.2f MB", totalSize / (1024.0 * 1024.0)));
+
+         // Test using configured protocol
+         long transferTime = testFileTransfer(testFiles);
+         log.info(String.format("%s: %6d ms (%.2f MB/s)",
+               protocol.toUpperCase(),
+               transferTime,
+               (totalSize / (1024.0 * 1024.0)) / (transferTime / 1000.0)));
+
+         // Verify files were uploaded
+         verifyFilesUploaded(testFiles);
+      }
+   }
+
+   private List<String> generateTestFiles(int count) throws IOException {
+      List<String> files = new ArrayList<>();
+      Random random = new Random(SEED);
+
+      for (int i = 0; i < count; i++) {
+         // Generate random file size between MIN and MAX
+         int fileSize = MIN_FILE_SIZE + random.nextInt(MAX_FILE_SIZE - MIN_FILE_SIZE);
+
+         File file = tempDir.resolve("test-file-" + i + ".dat").toFile();
+
+         // Generate random content
+         try (FileOutputStream fos = new FileOutputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int remaining = fileSize;
+
+            while (remaining > 0) {
+               int toWrite = Math.min(buffer.length, remaining);
+               random.nextBytes(buffer);
+               fos.write(buffer, 0, toWrite);
+               remaining -= toWrite;
+            }
+         }
+
+         files.add(file.getAbsolutePath());
+      }
+
+      return files;
+   }
+
+   private long testFileTransfer(List<String> files) throws Exception {
+      try (FileTransfer fileTransfer = new FileTransfer(session)) {
+         long startTime = System.currentTimeMillis();
+
+         fileTransfer.upload(files, remoteDir + "/");
+
+         long endTime = System.currentTimeMillis();
+         return endTime - startTime;
+      }
+   }
+
+   private void verifyFilesUploaded(List<String> files) throws IOException {
+      // Count files in remote directory
+      long uploadedFileCount = Files.list(remoteDir).count();
+      assertEquals(files.size(), uploadedFileCount,
+            "Number of uploaded files should match number of source files");
+
+      // Verify each file exists and has correct size
+      for (String sourceFilePath : files) {
+         File sourceFile = new File(sourceFilePath);
+         Path remotePath = remoteDir.resolve(sourceFile.getName());
+         assertTrue(Files.exists(remotePath),
+               "File should exist in remote directory: " + sourceFile.getName());
+         assertEquals(sourceFile.length(), Files.size(remotePath),
+               "File size should match: " + sourceFile);
+      }
+   }
+}

--- a/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferTest.java
@@ -1,202 +1,39 @@
 package io.hyperfoil.deploy.ssh;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static io.hyperfoil.deploy.ssh.FileTransfer.PROTOCOL_SCP;
+import static io.hyperfoil.deploy.ssh.FileTransfer.PROTOCOL_SFTP;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import java.util.UUID;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.sshd.client.SshClient;
-import org.apache.sshd.client.session.ClientSession;
-import org.apache.sshd.common.PropertyResolverUtils;
-import org.apache.sshd.core.CoreModuleProperties;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.hyperfoil.internal.Properties;
 
-/**
- * Performance test for FileTransfer class from SshDeployedAgent.
- * Tests the configured file transfer protocol (SCP or SFTP).
- * <p>
- * This test requires:
- * 1. SSH server running on localhost:22
- * 2. SSH key authentication configured (~/.ssh/id_rsa)
- * <p>
- * Set these system properties to configure the test:
- * - ssh.test.host (default: localhost)
- * - ssh.test.port (default: 22)
- * - ssh.test.user (default: current user)
- * - io.hyperfoil.file.transfer.client (default: scp) - set to "scp" or "sftp"
- * <p>
- * Example usage:
- * mvn test -Dtest=FileTransferTest -Dio.hyperfoil.file.transfer.client=scp
- * mvn test -Dtest=FileTransferTest -Dio.hyperfoil.file.transfer.client=sftp
- */
-@Tag("io.hyperfoil.test.Benchmark")
-public class FileTransferTest {
+public class FileTransferTest extends FileTransferBaseTest {
 
-   private static final Logger log = LogManager.getLogger(FileTransferTest.class);
+   @ParameterizedTest(name = "Testing upload targeting full path with protocol: {0}")
+   @ValueSource(strings = { PROTOCOL_SCP, PROTOCOL_SFTP })
+   public void testUploadTargetFullPath(String protocol) throws Exception {
 
-   private static final String TEST_HOST = System.getProperty("ssh.test.host", "localhost");
-   private static final int TEST_PORT = Integer.parseInt(System.getProperty("ssh.test.port", "22"));
-   private static final String TEST_USER = System.getProperty("ssh.test.user", System.getProperty("user.name"));
+      System.setProperty(Properties.FILE_TRANSFER_CLIENT, protocol);
 
-   // Use fixed seed for reproducible results
-   private static final long SEED = 42L;
-   private static final int MIN_FILE_SIZE = 1024; // 1KB
-   private static final int MAX_FILE_SIZE = 1024 * 1024; // 1MB
+      String fileName = UUID.randomUUID() + ".txt";
+      Path localFile = Files.createFile(tempDir.resolve(fileName));
 
-   @TempDir
-   Path tempDir;
+      // targetFile is a complete file path including the filename
+      String targetFile = remoteDir.toAbsolutePath() + File.separator + fileName;
 
-   @TempDir
-   Path remoteDir;
-
-   private SshClient client;
-   private ClientSession session;
-
-   @BeforeEach
-   public void setup() throws Exception {
-      client = SshClient.setUpDefaultClient();
-      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.IDLE_TIMEOUT.getName(), Long.MAX_VALUE);
-      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.NIO2_READ_TIMEOUT.getName(), Long.MAX_VALUE);
-      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.NIO_WORKERS.getName(), 1);
-
-      client.start();
-      client.setServerKeyVerifier((clientSession, remoteAddress, serverKey) -> true);
-
-      // Connect and authenticate
-      session = client.connect(TEST_USER, TEST_HOST, TEST_PORT).verify(15000).getSession();
-      session.auth().verify(10000);
-   }
-
-   @AfterEach
-   public void teardown() throws Exception {
-      if (session != null) {
-         session.close();
-      }
-
-      if (client != null) {
-         client.stop();
-      }
-
-      cleanupFolder(tempDir);
-      cleanupFolder(remoteDir);
-   }
-
-   @Test
-   public void testFileTransferPerformance() throws Exception {
-      String protocol = System.getProperty(Properties.FILE_TRANSFER_CLIENT, "scp");
-
-      log.info("=== FileTransfer Performance Test ===");
-      log.info("Protocol: {}", protocol);
-      log.info("Host: {}@{}:{}", TEST_USER, TEST_HOST, TEST_PORT);
-      log.info("Remote directory: {}", remoteDir);
-      log.info("Seed: " + SEED);
-
-      int[] fileCounts = { 1, 10, 100, 1000 };
-
-      for (int fileCount : fileCounts) {
-         log.info("--- Testing with {} file(s) ---", fileCount);
-
-         // Generate test files
-         List<String> testFiles = generateTestFiles(fileCount);
-         long totalSize = 0;
-         for (String f : testFiles) {
-            totalSize += new File(f).length();
-         }
-         log.info(String.format("Total size: %.2f MB", totalSize / (1024.0 * 1024.0)));
-
-         // Test using configured protocol
-         long transferTime = testFileTransfer(testFiles);
-         log.info(String.format("%s: %6d ms (%.2f MB/s)",
-               protocol.toUpperCase(),
-               transferTime,
-               (totalSize / (1024.0 * 1024.0)) / (transferTime / 1000.0)));
-
-         // Verify files were uploaded
-         verifyFilesUploaded(testFiles);
-      }
-   }
-
-   private List<String> generateTestFiles(int count) throws IOException {
-      List<String> files = new ArrayList<>();
-      Random random = new Random(SEED);
-
-      for (int i = 0; i < count; i++) {
-         // Generate random file size between MIN and MAX
-         int fileSize = MIN_FILE_SIZE + random.nextInt(MAX_FILE_SIZE - MIN_FILE_SIZE);
-
-         File file = tempDir.resolve("test-file-" + i + ".dat").toFile();
-
-         // Generate random content
-         try (FileOutputStream fos = new FileOutputStream(file)) {
-            byte[] buffer = new byte[8192];
-            int remaining = fileSize;
-
-            while (remaining > 0) {
-               int toWrite = Math.min(buffer.length, remaining);
-               random.nextBytes(buffer);
-               fos.write(buffer, 0, toWrite);
-               remaining -= toWrite;
-            }
-         }
-
-         files.add(file.getAbsolutePath());
-      }
-
-      return files;
-   }
-
-   private long testFileTransfer(List<String> files) throws Exception {
       try (FileTransfer fileTransfer = new FileTransfer(session)) {
-         long startTime = System.currentTimeMillis();
-
-         fileTransfer.upload(files, remoteDir + "/");
-
-         long endTime = System.currentTimeMillis();
-         return endTime - startTime;
+         // no exception expected
+         fileTransfer.upload(localFile.toAbsolutePath().toString(), targetFile);
       }
-   }
 
-   private void verifyFilesUploaded(List<String> files) throws IOException {
-      // Count files in remote directory
-      long uploadedFileCount = Files.list(remoteDir).count();
-      assertEquals(files.size(), uploadedFileCount,
-            "Number of uploaded files should match number of source files");
-
-      // Verify each file exists and has correct size
-      for (String sourceFilePath : files) {
-         File sourceFile = new File(sourceFilePath);
-         Path remotePath = remoteDir.resolve(sourceFile.getName());
-         assertTrue(Files.exists(remotePath),
-               "File should exist in remote directory: " + sourceFile.getName());
-         assertEquals(sourceFile.length(), Files.size(remotePath),
-               "File size should match: " + sourceFile);
-      }
-   }
-
-   private void cleanupFolder(Path folder) throws IOException {
-      try (var files = Files.list(folder)) {
-         files.forEach(p -> {
-            try {
-               Files.deleteIfExists(p);
-            } catch (IOException e) {
-               log.warn("Failed to clean up {}", p, e);
-            }
-         });
-      }
+      // Assert the file exists exactly where we directed it
+      assertTrue(Files.exists(remoteDir.resolve(fileName)), "File should be created at the exact explicit path.");
    }
 }

--- a/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferTest.java
@@ -91,6 +91,9 @@ public class FileTransferTest {
       if (client != null) {
          client.stop();
       }
+
+      cleanupFolder(tempDir);
+      cleanupFolder(remoteDir);
    }
 
    @Test
@@ -182,6 +185,18 @@ public class FileTransferTest {
                "File should exist in remote directory: " + sourceFile.getName());
          assertEquals(sourceFile.length(), Files.size(remotePath),
                "File size should match: " + sourceFile);
+      }
+   }
+
+   private void cleanupFolder(Path folder) throws IOException {
+      try (var files = Files.list(folder)) {
+         files.forEach(p -> {
+            try {
+               Files.deleteIfExists(p);
+            } catch (IOException e) {
+               log.warn("Failed to clean up {}", p, e);
+            }
+         });
       }
    }
 }

--- a/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferTest.java
@@ -1,0 +1,187 @@
+package io.hyperfoil.deploy.ssh;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.sshd.client.SshClient;
+import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.PropertyResolverUtils;
+import org.apache.sshd.core.CoreModuleProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.hyperfoil.internal.Properties;
+
+/**
+ * Performance test for FileTransfer class from SshDeployedAgent.
+ * Tests the configured file transfer protocol (SCP or SFTP).
+ * <p>
+ * This test requires:
+ * 1. SSH server running on localhost:22
+ * 2. SSH key authentication configured (~/.ssh/id_rsa)
+ * <p>
+ * Set these system properties to configure the test:
+ * - ssh.test.host (default: localhost)
+ * - ssh.test.port (default: 22)
+ * - ssh.test.user (default: current user)
+ * - io.hyperfoil.file.transfer.client (default: scp) - set to "scp" or "sftp"
+ * <p>
+ * Example usage:
+ * mvn test -Dtest=FileTransferPerformanceTest -Dio.hyperfoil.file.transfer.client=scp
+ * mvn test -Dtest=FileTransferPerformanceTest -Dio.hyperfoil.file.transfer.client=sftp
+ */
+@Tag("io.hyperfoil.test.Benchmark")
+public class FileTransferTest {
+
+   private static final Logger log = LogManager.getLogger(FileTransferTest.class);
+
+   private static final String TEST_HOST = System.getProperty("ssh.test.host", "localhost");
+   private static final int TEST_PORT = Integer.parseInt(System.getProperty("ssh.test.port", "22"));
+   private static final String TEST_USER = System.getProperty("ssh.test.user", System.getProperty("user.name"));
+
+   // Use fixed seed for reproducible results
+   private static final long SEED = 42L;
+   private static final int MIN_FILE_SIZE = 1024; // 1KB
+   private static final int MAX_FILE_SIZE = 1024 * 1024; // 1MB
+
+   @TempDir
+   Path tempDir;
+
+   @TempDir
+   Path remoteDir;
+
+   private SshClient client;
+   private ClientSession session;
+
+   @BeforeEach
+   public void setup() throws Exception {
+      client = SshClient.setUpDefaultClient();
+      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.IDLE_TIMEOUT.getName(), Long.MAX_VALUE);
+      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.NIO2_READ_TIMEOUT.getName(), Long.MAX_VALUE);
+      PropertyResolverUtils.updateProperty(client, CoreModuleProperties.NIO_WORKERS.getName(), 1);
+
+      client.start();
+      client.setServerKeyVerifier((clientSession, remoteAddress, serverKey) -> true);
+
+      // Connect and authenticate
+      session = client.connect(TEST_USER, TEST_HOST, TEST_PORT).verify(15000).getSession();
+      session.auth().verify(10000);
+   }
+
+   @AfterEach
+   public void teardown() throws Exception {
+      if (session != null) {
+         session.close();
+      }
+
+      if (client != null) {
+         client.stop();
+      }
+   }
+
+   @Test
+   public void testFileTransferPerformance() throws Exception {
+      String protocol = System.getProperty(Properties.FILE_TRANSFER_CLIENT, "scp");
+
+      log.info("=== FileTransfer Performance Test ===");
+      log.info("Protocol: {}", protocol);
+      log.info("Host: {}@{}:{}", TEST_USER, TEST_HOST, TEST_PORT);
+      log.info("Remote directory: {}", remoteDir);
+      log.info("Seed: " + SEED);
+
+      int[] fileCounts = { 1, 10, 100, 1000 };
+
+      for (int fileCount : fileCounts) {
+         log.info("--- Testing with {} file(s) ---", fileCount);
+
+         // Generate test files
+         List<String> testFiles = generateTestFiles(fileCount);
+         long totalSize = 0;
+         for (String f : testFiles) {
+            totalSize += new File(f).length();
+         }
+         log.info(String.format("Total size: %.2f MB", totalSize / (1024.0 * 1024.0)));
+
+         // Test using configured protocol
+         long transferTime = testFileTransfer(testFiles);
+         log.info(String.format("%s: %6d ms (%.2f MB/s)",
+               protocol.toUpperCase(),
+               transferTime,
+               (totalSize / (1024.0 * 1024.0)) / (transferTime / 1000.0)));
+
+         // Verify files were uploaded
+         verifyFilesUploaded(testFiles);
+      }
+   }
+
+   private List<String> generateTestFiles(int count) throws IOException {
+      List<String> files = new ArrayList<>();
+      Random random = new Random(SEED);
+
+      for (int i = 0; i < count; i++) {
+         // Generate random file size between MIN and MAX
+         int fileSize = MIN_FILE_SIZE + random.nextInt(MAX_FILE_SIZE - MIN_FILE_SIZE);
+
+         File file = tempDir.resolve("test-file-" + i + ".dat").toFile();
+
+         // Generate random content
+         try (FileOutputStream fos = new FileOutputStream(file)) {
+            byte[] buffer = new byte[8192];
+            int remaining = fileSize;
+
+            while (remaining > 0) {
+               int toWrite = Math.min(buffer.length, remaining);
+               random.nextBytes(buffer);
+               fos.write(buffer, 0, toWrite);
+               remaining -= toWrite;
+            }
+         }
+
+         files.add(file.getAbsolutePath());
+      }
+
+      return files;
+   }
+
+   private long testFileTransfer(List<String> files) throws Exception {
+      try (FileTransfer fileTransfer = new FileTransfer(session)) {
+         long startTime = System.currentTimeMillis();
+
+         fileTransfer.upload(files, remoteDir + "/");
+
+         long endTime = System.currentTimeMillis();
+         return endTime - startTime;
+      }
+   }
+
+   private void verifyFilesUploaded(List<String> files) throws IOException {
+      // Count files in remote directory
+      long uploadedFileCount = Files.list(remoteDir).count();
+      assertEquals(files.size(), uploadedFileCount,
+            "Number of uploaded files should match number of source files");
+
+      // Verify each file exists and has correct size
+      for (String sourceFilePath : files) {
+         File sourceFile = new File(sourceFilePath);
+         Path remotePath = remoteDir.resolve(sourceFile.getName());
+         assertTrue(Files.exists(remotePath),
+               "File should exist in remote directory: " + sourceFile.getName());
+         assertEquals(sourceFile.length(), Files.size(remotePath),
+               "File size should match: " + sourceFile);
+      }
+   }
+}

--- a/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/deploy/ssh/FileTransferTest.java
@@ -41,8 +41,8 @@ import io.hyperfoil.internal.Properties;
  * - io.hyperfoil.file.transfer.client (default: scp) - set to "scp" or "sftp"
  * <p>
  * Example usage:
- * mvn test -Dtest=FileTransferPerformanceTest -Dio.hyperfoil.file.transfer.client=scp
- * mvn test -Dtest=FileTransferPerformanceTest -Dio.hyperfoil.file.transfer.client=sftp
+ * mvn test -Dtest=FileTransferTest -Dio.hyperfoil.file.transfer.client=scp
+ * mvn test -Dtest=FileTransferTest -Dio.hyperfoil.file.transfer.client=sftp
  */
 @Tag("io.hyperfoil.test.Benchmark")
 public class FileTransferTest {


### PR DESCRIPTION
Add a configurable file transfer client with SCP/SFTP support

The default behavior will be scp with array, but the user is allowed to change to sftp via `-Dio.hyperfoil.file.transfer.client=sftp`

This can boost the copy by around 11x

Here is the raw data and ratio.
| Files | scp with array (Baseline) | sftp  |
|---|---|---|
| 1 | 304 ms | 15 ms (20.27x faster) |
| 10 | 540 ms | 50 ms (10.80x faster) |
| 100 | 3442 ms | 296 ms (11.63x faster) |
| 1000 | 33474 ms | 2760 ms (12.13x faster) |

Reproducer:
```
mvn test -Dtest=FileTransferPerformanceTest -Dio.hyperfoil.file.transfer.client=scp
mvn test -Dtest=FileTransferPerformanceTest -Dio.hyperfoil.file.transfer.client=sftp
```
