### PR TITLE
Fix wrk/wrk2 calibration SLA failure cancelling test phase

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/WrkScenario.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/WrkScenario.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.hyperfoil.api.config.Benchmark;
 import io.hyperfoil.api.config.BenchmarkBuilder;
 import io.hyperfoil.api.config.PhaseBuilder;
 import io.hyperfoil.core.handlers.TransferSizeRecorder;
@@ -64,7 +65,8 @@ public abstract class WrkScenario {
                   .useHttpCache(useHttpCache)
                .endHttp()
             .endPlugin()
-            .threads(threads);
+            .threads(threads)
+            .failurePolicy(Benchmark.FailurePolicy.CONTINUE);
       // @formatter:on
       if (agentParam != null) {
          for (Map.Entry<String, String> agent : agentParam.entrySet()) {

--- a/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
+++ b/clustering/src/main/java/io/hyperfoil/clustering/ControllerVerticle.java
@@ -481,7 +481,7 @@ public class ControllerVerticle extends AbstractVerticle implements NodeListener
             run.newGlobalData.putAll(run.phases.get(phase).completeGlobalData());
             break;
       }
-      if (controllerPhase.isFailed()) {
+      if (controllerPhase.isFailed() && run.benchmark.failurePolicy() == Benchmark.FailurePolicy.CANCEL) {
          failNotStartedPhases(run, controllerPhase);
       }
    }

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
@@ -39,7 +39,7 @@ public class WrkTest extends BaseWrkBenchmarkTest {
       Wrk cmd = new Wrk();
       int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "--latency", "--timeout", "1s",
             "localhost:" + httpServer.actualPort() + "/unpredictable" });
-      assertEquals(CommandResult.FAILURE.getResultValue(), result);
+      assertEquals(CommandResult.SUCCESS.getResultValue(), result);
    }
 
    @Test
@@ -98,6 +98,26 @@ public class WrkTest extends BaseWrkBenchmarkTest {
    }
 
    @Test
+   public void testWrk2CalibrationDoesNotCancelTestPhase() throws CommandNotFoundException {
+      Wrk2 cmd = new Wrk2();
+      int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "-R", "60000", "--latency", "--timeout", "1s",
+            "localhost:" + httpServer.actualPort() + "/highway" });
+
+      CommandContainer<HyperfoilCommandInvocation> commandContainer = cmd.getCommandRegistry().getCommand("wrk2", null);
+      ProcessedCommand processedCommand = commandContainer.getParser().getProcessedCommand();
+      Wrk2.Wrk2Command wrk2Command = (Wrk2.Wrk2Command) processedCommand.getCommand();
+      WrkAbstract.WrkCommandResult wrkCommandResult = wrk2Command.getWrkCommandResult();
+
+      assertEquals(CommandResult.SUCCESS.getResultValue(), result,
+            "wrk2 should succeed even when calibration SLA fails — wrk2 does not enforce SLA");
+      assertFalse(wrkCommandResult.getRequestStatisticsResponse().statistics.isEmpty());
+      boolean testPhaseFound = wrkCommandResult.getRequestStatisticsResponse().statistics.stream()
+            .anyMatch(rs -> "test".equals(rs.phase));
+      assertTrue(testPhaseFound,
+            "Test phase must have statistics even when calibration fails SLA validation");
+   }
+
+   @Test
    public void testWrk2HighLoad() throws CommandNotFoundException {
       Wrk2 cmd = new Wrk2();
       int result = cmd.exec(new String[] { "-c", "10", "-d", "5s", "-R", "20000", "--latency", "--timeout", "1s",
@@ -109,7 +129,9 @@ public class WrkTest extends BaseWrkBenchmarkTest {
       Wrk2.Wrk2Command wrk2Command = (Wrk2.Wrk2Command) processedCommand.getCommand();
       WrkAbstract.WrkCommandResult wrkCommandResult = wrk2Command.getWrkCommandResult();
 
-      // assert
+      // At 20K rate with 10 connections against /unpredictable, the test phase runs but
+      // all sessions block waiting for connections and time out — no test-phase stats are produced.
+      // The command returns FAILURE because it cannot find test-phase statistics to print.
       assertEquals(CommandResult.FAILURE.getResultValue(), result);
       assertFalse(wrkCommandResult.getRequestStatisticsResponse().statistics.isEmpty());
       for (RequestStats requestStats : wrkCommandResult.getRequestStatisticsResponse().statistics) {


### PR DESCRIPTION
Fixes a regression where calibration-phase SLA failures cancel the test phase in wrk/wrk2 commands (#790).

### Root cause

1. **wrk/wrk2 commands used the default `CANCEL` failure policy.** Calibration is a warmup phase — SLA failures during warmup (e.g. JIT outliers) should not abort the run.

2. **`ControllerVerticle.tryProgressStatus()` ignored `failurePolicy`.** The unconditional `isFailed()` → cancel path was added in 6ce78a75 (May 2019), two years before `failurePolicy` was introduced in 8328d824 (April 2021). When Radim added `failurePolicy`, he correctly guarded the SLA validation path in `tryCompletePhase()` but missed this second cancellation path in `tryProgressStatus()`.

### Changes

- **`WrkScenario`**: Set `failurePolicy(CONTINUE)` — SLA failures are still recorded but don't cancel phases. Scoped to wrk/wrk2 only; user-defined benchmarks keep the `CANCEL` default.
- **`ControllerVerticle`**: Guard the `tryProgressStatus()` cancellation path with the `failurePolicy` check, matching `tryCompletePhase()`.
- **`WrkTest`**: Add `testWrk2CalibrationDoesNotCancelTestPhase` (60K rate, 10 connections — calibration SLA fails but test phase must run). Update `testWrkUnpredictable` to expect `SUCCESS` (test phase now runs instead of being cancelled).

Fixes #790
