### PR TITLE
fix(http): handle resource cleanup and prevent NPE during phase termination

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/connection/Connection.java
+++ b/api/src/main/java/io/hyperfoil/api/connection/Connection.java
@@ -12,9 +12,22 @@ public interface Connection {
 
    void onAcquire();
 
+   /**
+    * Cancels one pending acquisition slot (decrements aboutToSend).
+    * Called by the pool when a consumer that was handed this connection is gone
+    * and will never call request(), so the slot must be returned.
+    */
+   void cancelAcquire();
+
    boolean isAvailable();
 
    int inFlight();
+
+   /**
+    * Returns the number of requests that are actually on the wire (sent but not yet responded),
+    * excluding pending acquisition slots (aboutToSend).
+    */
+   int pendingRequestCount();
 
    /**
     * This is an external request to close the connection

--- a/api/src/main/java/io/hyperfoil/api/session/Session.java
+++ b/api/src/main/java/io/hyperfoil/api/session/Session.java
@@ -9,7 +9,7 @@ import io.hyperfoil.api.connection.Request;
 import io.hyperfoil.api.statistics.SessionStatistics;
 import io.hyperfoil.api.statistics.Statistics;
 import io.netty.util.concurrent.EventExecutor;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 public interface Session {
 
@@ -106,7 +106,17 @@ public interface Session {
    /**
     * Run anything that can be executed.
     */
-   Future<Void> proceed();
+   void proceed();
+
+   /**
+    * Like {@link #proceed()}, but completes {@code promise} when the scheduled run finishes
+    * (successfully, with a stop, or with a failure). Only used by phase termination logic;
+    * regular call sites should use {@link #proceed()}.
+    */
+   default void proceedAndAwait(Promise<Void> promise) {
+      proceed();
+      promise.complete();
+   }
 
    void reset();
 

--- a/api/src/main/java/io/hyperfoil/api/session/Session.java
+++ b/api/src/main/java/io/hyperfoil/api/session/Session.java
@@ -9,6 +9,7 @@ import io.hyperfoil.api.connection.Request;
 import io.hyperfoil.api.statistics.SessionStatistics;
 import io.hyperfoil.api.statistics.Statistics;
 import io.netty.util.concurrent.EventExecutor;
+import io.vertx.core.Future;
 
 public interface Session {
 
@@ -105,7 +106,7 @@ public interface Session {
    /**
     * Run anything that can be executed.
     */
-   void proceed();
+   Future<Void> proceed();
 
    void reset();
 

--- a/api/src/main/java/io/hyperfoil/api/session/Session.java
+++ b/api/src/main/java/io/hyperfoil/api/session/Session.java
@@ -124,6 +124,8 @@ public interface Session {
 
    void currentRequest(Request request);
 
+   void tryTerminate();
+
    enum VarType {
       OBJECT,
       INTEGER
@@ -152,6 +154,10 @@ public interface Session {
       }
 
       default void destroy() {
+      }
+
+      default void onSessionTryTerminate(Session session) {
+
       }
    }
 

--- a/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
@@ -205,4 +205,9 @@ public class FakeSession implements Session {
    public void currentRequest(Request request) {
 
    }
+
+   @Override
+   public void tryTerminate() {
+
+   }
 }

--- a/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
@@ -14,7 +14,6 @@ import io.hyperfoil.api.session.ThreadData;
 import io.hyperfoil.api.statistics.SessionStatistics;
 import io.hyperfoil.api.statistics.Statistics;
 import io.netty.util.concurrent.EventExecutor;
-import io.vertx.core.Future;
 
 public class FakeSession implements Session {
 
@@ -168,8 +167,7 @@ public class FakeSession implements Session {
    }
 
    @Override
-   public Future<Void> proceed() {
-      return Future.succeededFuture();
+   public void proceed() {
    }
 
    @Override

--- a/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
+++ b/benchmarks/src/main/java/io/hyperfoil/core/impl/FakeSession.java
@@ -14,6 +14,7 @@ import io.hyperfoil.api.session.ThreadData;
 import io.hyperfoil.api.statistics.SessionStatistics;
 import io.hyperfoil.api.statistics.Statistics;
 import io.netty.util.concurrent.EventExecutor;
+import io.vertx.core.Future;
 
 public class FakeSession implements Session {
 
@@ -167,8 +168,8 @@ public class FakeSession implements Session {
    }
 
    @Override
-   public void proceed() {
-
+   public Future<Void> proceed() {
+      return Future.succeededFuture();
    }
 
    @Override

--- a/core/src/main/java/io/hyperfoil/core/impl/PhaseInstanceImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/PhaseInstanceImpl.java
@@ -141,18 +141,19 @@ public abstract class PhaseInstanceImpl implements PhaseInstance {
          setTerminated();
       } else if (sessionList != null && status == Status.TERMINATING) {
          List<Future<Void>> proceedFutures = new ArrayList<>();
+         List<Session> sessionsToTerminate;
          synchronized (sessionList) {
+            sessionsToTerminate = new ArrayList<>(sessionList);
             for (int i = 0; i < sessionList.size(); i++) {
                Session session = sessionList.get(i);
                if (session.isActive()) {
                   if (session.executor().inEventLoop()) {
-                     session.proceed();
+                     proceedFutures.add(session.proceed());
                   } else {
                      Promise<Void> promise = Promise.promise();
                      session.executor().execute(() -> {
                         try {
-                           session.proceed();
-                           promise.complete();
+                           session.proceed().onComplete(promise);
                         } catch (Throwable t) {
                            promise.fail(t);
                         }
@@ -161,17 +162,13 @@ public abstract class PhaseInstanceImpl implements PhaseInstance {
                   }
                }
             }
-            for (int i = 0; i < sessionList.size(); i++) {
-               Session session = sessionList.get(i);
-               // add resources back
-               session.tryTerminate();
-            }
          }
-
          Future<Void> proceedPhaseComplete = proceedFutures.isEmpty() ? Future.succeededFuture()
                : Future.all(proceedFutures).mapEmpty();
-
          proceedPhaseComplete.onComplete(result -> {
+            for (Session session : sessionsToTerminate) {
+               session.tryTerminate();
+            }
             if (result.succeeded()) {
                log.debug("All sessions terminated for phase '{}'.", def.name);
             } else {

--- a/core/src/main/java/io/hyperfoil/core/impl/PhaseInstanceImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/PhaseInstanceImpl.java
@@ -147,18 +147,18 @@ public abstract class PhaseInstanceImpl implements PhaseInstance {
             for (int i = 0; i < sessionList.size(); i++) {
                Session session = sessionList.get(i);
                if (session.isActive()) {
+                  Promise<Void> promise = Promise.promise();
+                  proceedFutures.add(promise.future());
                   if (session.executor().inEventLoop()) {
-                     proceedFutures.add(session.proceed());
+                     session.proceedAndAwait(promise);
                   } else {
-                     Promise<Void> promise = Promise.promise();
                      session.executor().execute(() -> {
                         try {
-                           session.proceed().onComplete(promise);
+                           session.proceedAndAwait(promise);
                         } catch (Throwable t) {
                            promise.fail(t);
                         }
                      });
-                     proceedFutures.add(promise.future());
                   }
                }
             }

--- a/core/src/main/java/io/hyperfoil/core/impl/PhaseInstanceImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/impl/PhaseInstanceImpl.java
@@ -161,6 +161,11 @@ public abstract class PhaseInstanceImpl implements PhaseInstance {
                   }
                }
             }
+            for (int i = 0; i < sessionList.size(); i++) {
+               Session session = sessionList.get(i);
+               // add resources back
+               session.tryTerminate();
+            }
          }
 
          Future<Void> proceedPhaseComplete = proceedFutures.isEmpty() ? Future.succeededFuture()

--- a/core/src/main/java/io/hyperfoil/core/session/SessionImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/session/SessionImpl.java
@@ -64,6 +64,7 @@ class SessionImpl implements Session {
    private final Runnable deferredStart = this::deferredStart;
 
    private final Runnable runTask = this::run;
+   private Promise<Void> proceedPromise;
 
    SessionImpl(Scenario scenario, int threadId, int uniqueId) {
       this.sequencePool = new LimitedPool<>(scenario.maxSequences(), SequenceInstance::new);
@@ -243,15 +244,25 @@ class SessionImpl implements Session {
 
    private void run() {
       scheduled = false;
+      Promise<Void> currentPromise = proceedPromise;
+      proceedPromise = null;
       try {
          runSession();
+         if (currentPromise != null) {
+            currentPromise.tryComplete();
+         }
       } catch (SessionStopException e) {
          log.trace("#{} Session was stopped.", uniqueId);
-         // this one is OK
+         if (currentPromise != null) {
+            currentPromise.tryComplete();
+         }
       } catch (Throwable t) {
          log.error(new FormattedMessage("#{} Uncaught error", uniqueId), t);
          if (phase != null) {
             phase.fail(t);
+         }
+         if (currentPromise != null) {
+            currentPromise.tryFail(t);
          }
       }
    }
@@ -460,19 +471,11 @@ class SessionImpl implements Session {
       if (!scheduled) {
          scheduled = true;
          Promise<Void> promise = Promise.promise();
-
-         executor.execute(() -> {
-            try {
-               runTask.run();
-               promise.complete();
-            } catch (Throwable t) {
-               promise.fail(t);
-            }
-         });
-
+         proceedPromise = promise;
+         executor.execute(runTask);
          return promise.future();
       }
-      return Future.succeededFuture();
+      return proceedPromise != null ? proceedPromise.future() : Future.succeededFuture();
    }
 
    @Override
@@ -490,6 +493,10 @@ class SessionImpl implements Session {
       startTimestampMillis = -1;
       startNanoTime = -1;
       resetting = true;
+
+      scheduled = false;
+      proceedPromise = null;
+
       for (int i = 0; i < allVars.size(); ++i) {
          allVars.get(i).unset();
       }

--- a/core/src/main/java/io/hyperfoil/core/session/SessionImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/session/SessionImpl.java
@@ -541,6 +541,14 @@ class SessionImpl implements Session {
    }
 
    @Override
+   public void tryTerminate() {
+      for (int i = 0; i < allResources.size(); i++) {
+         Resource r = allResources.get(i);
+         r.onSessionTryTerminate(this);
+      }
+   }
+
+   @Override
    public String toString() {
       StringBuilder sb = new StringBuilder("#").append(uniqueId)
             .append(" (").append(phase != null ? phase.definition().name : null).append(") ")

--- a/core/src/main/java/io/hyperfoil/core/session/SessionImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/session/SessionImpl.java
@@ -28,7 +28,6 @@ import io.hyperfoil.api.session.ThreadData;
 import io.hyperfoil.api.statistics.SessionStatistics;
 import io.hyperfoil.api.statistics.Statistics;
 import io.netty.util.concurrent.EventExecutor;
-import io.vertx.core.Future;
 import io.vertx.core.Promise;
 
 class SessionImpl implements Session {
@@ -64,7 +63,7 @@ class SessionImpl implements Session {
    private final Runnable deferredStart = this::deferredStart;
 
    private final Runnable runTask = this::run;
-   private Promise<Void> proceedPromise;
+   private Promise<Void> proceedPromise; // non-null iff scheduled==true and a caller requested notification
 
    SessionImpl(Scenario scenario, int threadId, int uniqueId) {
       this.sequencePool = new LimitedPool<>(scenario.maxSequences(), SequenceInstance::new);
@@ -465,17 +464,30 @@ class SessionImpl implements Session {
    }
 
    @Override
-   public Future<Void> proceed() {
+   public void proceed() {
       assert executor.inEventLoop();
-
       if (!scheduled) {
          scheduled = true;
-         Promise<Void> promise = Promise.promise();
+         executor.execute(runTask);
+      }
+   }
+
+   @Override
+   public void proceedAndAwait(Promise<Void> promise) {
+      assert executor.inEventLoop();
+      if (!scheduled) {
+         scheduled = true;
          proceedPromise = promise;
          executor.execute(runTask);
-         return promise.future();
+      } else {
+         // Already scheduled: chain onto the existing promise so this caller is also notified.
+         if (proceedPromise != null) {
+            proceedPromise.future().onComplete(promise);
+         } else {
+            // scheduled=true but no promise was registered — track this one now.
+            proceedPromise = promise;
+         }
       }
-      return proceedPromise != null ? proceedPromise.future() : Future.succeededFuture();
    }
 
    @Override

--- a/core/src/main/java/io/hyperfoil/core/session/SessionImpl.java
+++ b/core/src/main/java/io/hyperfoil/core/session/SessionImpl.java
@@ -28,6 +28,8 @@ import io.hyperfoil.api.session.ThreadData;
 import io.hyperfoil.api.statistics.SessionStatistics;
 import io.hyperfoil.api.statistics.Statistics;
 import io.netty.util.concurrent.EventExecutor;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 class SessionImpl implements Session {
    private static final Logger log = LogManager.getLogger(SessionImpl.class);
@@ -452,12 +454,25 @@ class SessionImpl implements Session {
    }
 
    @Override
-   public void proceed() {
+   public Future<Void> proceed() {
       assert executor.inEventLoop();
+
       if (!scheduled) {
          scheduled = true;
-         executor.execute(runTask);
+         Promise<Void> promise = Promise.promise();
+
+         executor.execute(() -> {
+            try {
+               runTask.run();
+               promise.complete();
+            } catch (Throwable t) {
+               promise.fail(t);
+            }
+         });
+
+         return promise.future();
       }
+      return Future.succeededFuture();
    }
 
    @Override

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -64,6 +64,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <log4j2.configurationFile>log4j2.xml</log4j2.configurationFile>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/http/src/main/java/io/hyperfoil/http/api/ConnectionConsumer.java
+++ b/http/src/main/java/io/hyperfoil/http/api/ConnectionConsumer.java
@@ -2,4 +2,8 @@ package io.hyperfoil.http.api;
 
 public interface ConnectionConsumer {
    void accept(HttpConnection connection);
+
+   default boolean isValid() {
+      return true;
+   }
 }

--- a/http/src/main/java/io/hyperfoil/http/api/ConnectionConsumer.java
+++ b/http/src/main/java/io/hyperfoil/http/api/ConnectionConsumer.java
@@ -2,8 +2,4 @@ package io.hyperfoil.http.api;
 
 public interface ConnectionConsumer {
    void accept(HttpConnection connection);
-
-   default boolean isValid() {
-      return true;
-   }
 }

--- a/http/src/main/java/io/hyperfoil/http/api/HttpConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/api/HttpConnectionPool.java
@@ -39,4 +39,8 @@ public interface HttpConnectionPool {
    default void onSessionTryTerminate() {
 
    }
+
+   default void cancelAcquire(HttpConnection connection) {
+
+   }
 }

--- a/http/src/main/java/io/hyperfoil/http/api/HttpConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/api/HttpConnectionPool.java
@@ -35,4 +35,8 @@ public interface HttpConnectionPool {
    void start(Handler<AsyncResult<Void>> handler);
 
    void shutdown();
+
+   default void onSessionTryTerminate() {
+
+   }
 }

--- a/http/src/main/java/io/hyperfoil/http/connection/ConnectionPoolStats.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/ConnectionPoolStats.java
@@ -10,7 +10,7 @@ import io.hyperfoil.core.impl.ConnectionStatsConsumer;
 import io.hyperfoil.core.util.Watermarks;
 import io.hyperfoil.http.api.HttpConnection;
 
-class ConnectionPoolStats {
+public class ConnectionPoolStats {
    private static final Logger log = LogManager.getLogger(ConnectionPoolStats.class);
    protected final String authority;
    protected final Watermarks usedConnections = new Watermarks();
@@ -28,6 +28,10 @@ class ConnectionPoolStats {
 
    public void decrementInFlight() {
       inFlight.decrementUsed();
+   }
+
+   public int inFlightCount() {
+      return inFlight.current();
    }
 
    public void visitConnectionStats(ConnectionStatsConsumer consumer) {

--- a/http/src/main/java/io/hyperfoil/http/connection/Http1xConnection.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/Http1xConnection.java
@@ -294,6 +294,17 @@ class Http1xConnection extends ChannelDuplexHandler implements HttpConnection {
    }
 
    @Override
+   public void cancelAcquire() {
+      assert aboutToSend > 0;
+      aboutToSend--;
+   }
+
+   @Override
+   public int pendingRequestCount() {
+      return inflights.size();
+   }
+
+   @Override
    public boolean isAvailable() {
       // Having pool not attached implies that the connection is not taken out of the pool
       // and therefore it's fully available

--- a/http/src/main/java/io/hyperfoil/http/connection/Http1xConnection.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/Http1xConnection.java
@@ -211,7 +211,11 @@ class Http1xConnection extends ChannelDuplexHandler implements HttpConnection {
       if (pool != null) {
          // Note: the pool might be already released if the completion handler
          // invoked another request which was served from cache.
-         pool.release(this, inFlight() == pipeliningLimit - 1 && !isClosed(), true);
+         boolean becameAvailable = inFlight() == pipeliningLimit - 1 && !isClosed();
+         if (log.isDebugEnabled()) {
+            log.debug("releasePoolAndPulse: {} inFlight={}, becameAvailable={}", this, inFlight(), becameAvailable);
+         }
+         pool.release(this, becameAvailable, true);
          pool.pulse();
       }
    }

--- a/http/src/main/java/io/hyperfoil/http/connection/Http2Connection.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/Http2Connection.java
@@ -88,6 +88,17 @@ class Http2Connection extends Http2EventAdapter implements HttpConnection {
    }
 
    @Override
+   public void cancelAcquire() {
+      assert aboutToSend > 0;
+      aboutToSend--;
+   }
+
+   @Override
+   public int pendingRequestCount() {
+      return streams.size();
+   }
+
+   @Override
    public boolean isAvailable() {
       return inFlight() < maxStreams;
    }

--- a/http/src/main/java/io/hyperfoil/http/connection/HttpDestinationTableImpl.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/HttpDestinationTableImpl.java
@@ -2,8 +2,10 @@ package io.hyperfoil.http.connection;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -80,11 +82,9 @@ public class HttpDestinationTableImpl implements HttpDestinationTable {
 
    @Override
    public void onSessionTryTerminate(Session session) {
-      for (HttpConnectionPool pool : byAuthority.values()) {
-         pool.onSessionTryTerminate();
-      }
-      for (HttpConnectionPool pool : byName.values()) {
-         pool.onSessionTryTerminate();
-      }
+      // avoid duplicated call to onSessionTryTerminate
+      Set<HttpConnectionPool> pools = new HashSet<>(byAuthority.values());
+      pools.addAll(byName.values());
+      pools.forEach(HttpConnectionPool::onSessionTryTerminate);
    }
 }

--- a/http/src/main/java/io/hyperfoil/http/connection/HttpDestinationTableImpl.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/HttpDestinationTableImpl.java
@@ -77,4 +77,14 @@ public class HttpDestinationTableImpl implements HttpDestinationTable {
    public Iterable<Map.Entry<String, HttpConnectionPool>> iterable() {
       return byAuthority.entrySet();
    }
+
+   @Override
+   public void onSessionTryTerminate(Session session) {
+      for (HttpConnectionPool pool : byAuthority.values()) {
+         pool.onSessionTryTerminate();
+      }
+      for (HttpConnectionPool pool : byName.values()) {
+         pool.onSessionTryTerminate();
+      }
+   }
 }

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -52,6 +52,7 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
    private final Deque<ConnectionConsumer> waiting = new ArrayDeque<>();
    private ScheduledFuture<?> pulseFuture;
    private ScheduledFuture<?> keepAliveFuture;
+   private boolean shouldPulse = true;
 
    SharedConnectionPool(HttpClientPoolImpl clientPool, EventLoop eventLoop, ConnectionPoolConfig sizeConfig) {
       super(clientPool.authority);
@@ -139,13 +140,14 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
          log.trace("Release {} (became available={} after request={})", connection, becameAvailable, afterRequest);
       }
       if (becameAvailable) {
-         assert !connection.isClosed();
-         if (connection.inFlight() == 0) {
-            // We are adding to the beginning of the queue to prefer reusing connections rather than cycling
-            // too many often-idle connections
-            available.addFirst(connection);
-         } else {
-            available.addLast(connection);
+         if (!connection.isClosed()) {
+            if (connection.inFlight() == 0) {
+               // We are adding to the beginning of the queue to prefer reusing connections rather than cycling
+               // too many often-idle connections
+               available.addFirst(connection);
+            } else {
+               available.addLast(connection);
+            }
          }
       }
       if (afterRequest) {
@@ -192,8 +194,23 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
 
    @Override
    public void pulse() {
+      assert executor().inEventLoop();
       if (trace) {
          log.trace("Pulse to {} ({} waiting)", authority, waiting.size());
+      }
+      // session terminated, there is nothing that we can do
+      if (!shouldPulse) {
+         blockedSessions.decrementUsed(waiting.size());
+         assert blockedSessions.current() == 0;
+         waiting.clear();
+         // make the connections available again
+         for (HttpConnection conn : connections) {
+            if (!available.contains(conn)) {
+               release(conn, true, false);
+            }
+         }
+         shouldPulse = true;
+         return;
       }
       ConnectionConsumer consumer = waiting.poll();
       if (consumer != null) {
@@ -357,5 +374,10 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
             conn.context().flush();
          }
       });
+   }
+
+   @Override
+   public void onSessionTryTerminate() {
+      this.shouldPulse = false;
    }
 }

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -378,6 +378,9 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
 
    @Override
    public void onSessionTryTerminate() {
+      if (!executor().inEventLoop()) {
+         executor().execute(this::onSessionTryTerminate);
+      }
       this.shouldPulse = false;
    }
 }

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -136,6 +136,7 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
 
    @Override
    public void release(HttpConnection connection, boolean becameAvailable, boolean afterRequest) {
+      assert executor().inEventLoop();
       if (trace) {
          log.trace("Release {} (became available={} after request={})", connection, becameAvailable, afterRequest);
       }

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -396,6 +396,7 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
    public void onSessionTryTerminate() {
       if (!executor().inEventLoop()) {
          executor().execute(this::onSessionTryTerminate);
+         return;
       }
       this.shouldPulse = false;
    }

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -88,7 +88,10 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
                   usedConnections.incrementUsed();
                }
                connection.onAcquire();
-
+               if (log.isDebugEnabled()) {
+                  log.debug("acquireNow: acquired {} to {}, inFlight={} (after), connection.inFlight={}",
+                        connection, authority, inFlight.current(), connection.inFlight());
+               }
                return connection;
             } else {
                availableClosed--;
@@ -105,6 +108,10 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
 
    @Override
    public void acquire(boolean exclusiveConnection, ConnectionConsumer consumer) {
+      if (log.isDebugEnabled()) {
+         log.debug("acquire: {} exclusiveConnection={}, waiting={}, available={}, inFlight={}",
+               authority, exclusiveConnection, waiting.size(), available.size(), inFlight.current());
+      }
       HttpConnection connection = acquireNow(exclusiveConnection);
       if (connection != null) {
          consumer.accept(connection);
@@ -139,6 +146,16 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
       assert executor().inEventLoop();
       if (trace) {
          log.trace("Release {} (became available={} after request={})", connection, becameAvailable, afterRequest);
+      }
+      if (log.isDebugEnabled()) {
+         boolean alreadyInAvailable = available.contains(connection);
+         log.debug(
+               "release: {} becameAvailable={}, afterRequest={}, connection.inFlight={}, inFlight={} (before), available={}, alreadyInAvailable={}",
+               connection, becameAvailable, afterRequest, connection.inFlight(), inFlight.current(), available.size(),
+               alreadyInAvailable);
+         if (becameAvailable && !connection.isClosed() && alreadyInAvailable) {
+            log.debug("release: DUPLICATE! {} already in available queue", connection);
+         }
       }
       if (becameAvailable) {
          if (!connection.isClosed()) {
@@ -199,8 +216,15 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
       if (trace) {
          log.trace("Pulse to {} ({} waiting)", authority, waiting.size());
       }
+      if (log.isDebugEnabled()) {
+         log.debug("pulse: {} shouldPulse={}, waiting={}, available={}, inFlight={}",
+               authority, shouldPulse, waiting.size(), available.size(), inFlight.current());
+      }
       // session terminated, there is nothing that we can do
       if (!shouldPulse) {
+         if (log.isDebugEnabled()) {
+            log.debug("pulse: session terminated, releasing all non-available connections, waiting={}", waiting.size());
+         }
 
          blockedSessions.decrementUsed(waiting.size());
          waiting.clear();
@@ -211,6 +235,9 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
             if (!available.contains(conn)) {
                release(conn, true, false);
             }
+         }
+         if (log.isDebugEnabled()) {
+            log.debug("pulse: after releasing all, inFlight={}, available={}", inFlight.current(), available.size());
          }
          shouldPulse = true;
          return;
@@ -246,6 +273,11 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
    @Override
    public Collection<HttpConnection> connections() {
       return connections;
+   }
+
+   /** Returns the current number of entries in the available deque (for testing). */
+   public int availableCount() {
+      return available.size();
    }
 
    private void checkCreateConnections() {
@@ -384,6 +416,10 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
       if (!executor().inEventLoop()) {
          executor().execute(this::onSessionTryTerminate);
          return;
+      }
+      if (log.isDebugEnabled()) {
+         log.debug("onSessionTryTerminate: {} inFlight={}, available={}, waiting={}",
+               authority, inFlight.current(), available.size(), waiting.size());
       }
       this.shouldPulse = false;
    }

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -4,7 +4,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -202,23 +201,10 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
       // session terminated, there is nothing that we can do
       if (!shouldPulse) {
 
-         int removedCount = 0;
-         Iterator<ConnectionConsumer> iterator = waiting.iterator();
-         while (iterator.hasNext()) {
-            ConnectionConsumer consumer = iterator.next();
-            // allow valid consumer still being executed
-            if (!consumer.isValid()) {
-               iterator.remove();
-               removedCount++;
-            }
-         }
+         blockedSessions.decrementUsed(waiting.size());
+         waiting.clear();
 
-         blockedSessions.decrementUsed(removedCount);
-
-         if (blockedSessions.current() > 0) {
-            this.pulse();
-            return;
-         }
+         assert blockedSessions.current() == 0;
 
          for (HttpConnection conn : connections) {
             if (!available.contains(conn)) {

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -4,7 +4,9 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
@@ -53,6 +55,12 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
    private ScheduledFuture<?> pulseFuture;
    private ScheduledFuture<?> keepAliveFuture;
    private boolean shouldPulse = true;
+   /**
+    * Connections that were in-flight when a !shouldPulse drain ran and were therefore skipped.
+    * shouldPulse is only restored to true once all of them have finished their current request
+    * and called release() with afterRequest=true.
+    */
+   private final Set<HttpConnection> pendingDrainConnections = new HashSet<>();
 
    SharedConnectionPool(HttpClientPoolImpl clientPool, EventLoop eventLoop, ConnectionPoolConfig sizeConfig) {
       super(clientPool.authority);
@@ -153,23 +161,30 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
                "release: {} becameAvailable={}, afterRequest={}, connection.inFlight={}, inFlight={} (before), available={}, alreadyInAvailable={}",
                connection, becameAvailable, afterRequest, connection.inFlight(), inFlight.current(), available.size(),
                alreadyInAvailable);
-         if (becameAvailable && !connection.isClosed() && alreadyInAvailable) {
-            log.debug("release: DUPLICATE! {} already in available queue", connection);
-         }
       }
       if (becameAvailable) {
          if (!connection.isClosed()) {
             if (connection.inFlight() == 0) {
                // We are adding to the beginning of the queue to prefer reusing connections rather than cycling
                // too many often-idle connections
+               assert !available.contains(connection);
                available.addFirst(connection);
             } else {
+               assert !available.contains(connection);
                available.addLast(connection);
             }
          }
       }
       if (afterRequest) {
          inFlight.decrementUsed();
+         // Only relevant during drain: if this connection was deferred, remove it from the pending set.
+         if (!shouldPulse && pendingDrainConnections.remove(connection) && pendingDrainConnections.isEmpty()) {
+            shouldPulse = true;
+            // Drain any sessions that queued up while we were waiting for in-flight connections.
+            if (!waiting.isEmpty()) {
+               pulse();
+            }
+         }
       }
       if (connection.inFlight() == 0) {
          usedConnections.decrementUsed();
@@ -222,6 +237,12 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
       }
       // session terminated, there is nothing that we can do
       if (!shouldPulse) {
+         // If we are already waiting for in-flight connections to drain, do not re-enter the drain
+         // setup — release() will restore shouldPulse once the last pending connection returns.
+         if (!pendingDrainConnections.isEmpty()) {
+            return;
+         }
+
          if (log.isDebugEnabled()) {
             log.debug("pulse: session terminated, releasing all non-available connections, waiting={}", waiting.size());
          }
@@ -232,14 +253,37 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
          assert blockedSessions.current() == 0;
 
          for (HttpConnection conn : connections) {
-            if (!available.contains(conn)) {
+            // The following if/else block explicitly maps out the connection's lifecycle history,
+            // making edge cases easier to trace and debug.
+
+            // Only add to available if not already there and not still in-flight:
+            // in-flight connections will add themselves via releasePoolAndPulse() once
+            // their response arrives, so forcing becameAvailable=true here would create a duplicate.
+            if (available.contains(conn)) {
+               // already in the queue, skip
+            } else if (conn.pendingRequestCount() > 0) {
+               // Real HTTP requests are on the wire — wait for the server response.
+               pendingDrainConnections.add(conn);
+            } else if (conn.inFlight() > 0) {
+               // Only aboutToSend > 0: the consumer that acquired this connection is gone (session was
+               // reset before it could call request()). No HTTP request was ever sent, so this is NOT
+               // an afterRequest event. We manually undo the pool-level inFlight increment that
+               // acquireNow() made, then return the connection as available with afterRequest=false.
+               // Passing afterRequest=true here would be semantically wrong: it signals a completed
+               // HTTP request, which never happened, and would incorrectly trigger any per-request
+               // hooks (stats, pendingDrainConnections removal, etc.) inside release().
+               conn.cancelAcquire(); // conn.aboutToSend-- → conn.inFlight() now 0
+               inFlight.decrementUsed(); // undo the acquireNow() increment; not a completed request
+               release(conn, true, false); // afterRequest=false: no HTTP request ever took place
+            } else {
                release(conn, true, false);
             }
          }
-         if (log.isDebugEnabled()) {
-            log.debug("pulse: after releasing all, inFlight={}, available={}", inFlight.current(), available.size());
+         if (pendingDrainConnections.isEmpty()) {
+            // No in-flight connections to wait for — restore immediately.
+            shouldPulse = true;
          }
-         shouldPulse = true;
+         // else: shouldPulse stays false until release() drains pendingDrainConnections
          return;
       }
       ConnectionConsumer consumer = waiting.poll();

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -26,7 +26,7 @@ import io.vertx.core.Handler;
 /**
  * This instance is not thread-safe as it should be accessed only the {@link #executor()}.
  */
-class SharedConnectionPool extends ConnectionPoolStats implements HttpConnectionPool {
+public class SharedConnectionPool extends ConnectionPoolStats implements HttpConnectionPool {
    private static final Logger log = LogManager.getLogger(SharedConnectionPool.class);
    private static final boolean trace = log.isTraceEnabled();
    //TODO: configurable

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -272,9 +272,7 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
                // Passing afterRequest=true here would be semantically wrong: it signals a completed
                // HTTP request, which never happened, and would incorrectly trigger any per-request
                // hooks (stats, pendingDrainConnections removal, etc.) inside release().
-               conn.cancelAcquire(); // conn.aboutToSend-- → conn.inFlight() now 0
-               inFlight.decrementUsed(); // undo the acquireNow() increment; not a completed request
-               release(conn, true, false); // afterRequest=false: no HTTP request ever took place
+               cancelAcquire(conn);
             } else {
                release(conn, true, false);
             }
@@ -322,6 +320,14 @@ public class SharedConnectionPool extends ConnectionPoolStats implements HttpCon
    /** Returns the current number of entries in the available deque (for testing). */
    public int availableCount() {
       return available.size();
+   }
+
+   @Override
+   public void cancelAcquire(HttpConnection connection) {
+      assert executor().inEventLoop();
+      connection.cancelAcquire();
+      inFlight.decrementUsed();
+      release(connection, true, false);
    }
 
    private void checkCreateConnections() {

--- a/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
+++ b/http/src/main/java/io/hyperfoil/http/connection/SharedConnectionPool.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -200,10 +201,25 @@ class SharedConnectionPool extends ConnectionPoolStats implements HttpConnection
       }
       // session terminated, there is nothing that we can do
       if (!shouldPulse) {
-         blockedSessions.decrementUsed(waiting.size());
-         assert blockedSessions.current() == 0;
-         waiting.clear();
-         // make the connections available again
+
+         int removedCount = 0;
+         Iterator<ConnectionConsumer> iterator = waiting.iterator();
+         while (iterator.hasNext()) {
+            ConnectionConsumer consumer = iterator.next();
+            // allow valid consumer still being executed
+            if (!consumer.isValid()) {
+               iterator.remove();
+               removedCount++;
+            }
+         }
+
+         blockedSessions.decrementUsed(removedCount);
+
+         if (blockedSessions.current() > 0) {
+            this.pulse();
+            return;
+         }
+
          for (HttpConnection conn : connections) {
             if (!available.contains(conn)) {
                release(conn, true, false);

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
@@ -48,8 +48,7 @@ class HttpRequestContext implements Session.Resource, ConnectionConsumer {
          // No HTTP request was ever sent: undo the onAcquire() slot and return the connection
          // without recording an afterRequest event (which would corrupt the inFlight counter).
          if (connection != null && connection.pool() != null) {
-            connection.cancelAcquire();
-            connection.pool().release(connection, true, false);
+            connection.pool().cancelAcquire(connection);
          }
       }
    }

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
@@ -39,6 +39,8 @@ class HttpRequestContext implements Session.Resource, ConnectionConsumer {
          this.connection = connection;
          this.ready = true;
          this.request.session.proceed();
+      } else {
+         this.ready = false;
       }
    }
 
@@ -53,6 +55,11 @@ class HttpRequestContext implements Session.Resource, ConnectionConsumer {
          long blockedTime = System.nanoTime() - waitTimestamp;
          request.statistics().incrementBlockedTime(request.startTimestampMillis(), blockedTime);
       }
+   }
+
+   @Override
+   public boolean isValid() {
+      return ready;
    }
 
    public static final class Key implements Session.ResourceKey<HttpRequestContext> {

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
@@ -41,6 +41,9 @@ class HttpRequestContext implements Session.Resource, ConnectionConsumer {
          this.request.session.proceed();
       } else {
          this.ready = false;
+         if (connection != null) {
+            connection.pool().release(connection, true, true);
+         }
       }
    }
 

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
@@ -60,11 +60,6 @@ class HttpRequestContext implements Session.Resource, ConnectionConsumer {
       }
    }
 
-   @Override
-   public boolean isValid() {
-      return ready;
-   }
-
    public static final class Key implements Session.ResourceKey<HttpRequestContext> {
    }
 }

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
@@ -34,10 +34,12 @@ class HttpRequestContext implements Session.Resource, ConnectionConsumer {
 
    @Override
    public void accept(HttpConnection connection) {
-      assert request.session.executor().inEventLoop();
-      this.connection = connection;
-      this.ready = true;
-      this.request.session.proceed();
+      if (request != null) {
+         assert request.session.executor().inEventLoop();
+         this.connection = connection;
+         this.ready = true;
+         this.request.session.proceed();
+      }
    }
 
    public void startWaiting() {

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
@@ -44,9 +44,12 @@ class HttpRequestContext implements Session.Resource, ConnectionConsumer {
          // Due to Hyperfoil's asynchronous nature, a connection created via `handleNewConnection` can trigger a `pulse`.
          // During this pulse, a waiting consumer might call `accept` even in the termination phase.
          // Since the connection is only attached to the pool during `HttpRequest.send()`,
-         // It is perfectly fine for the connection to not have an attached pool in this scenario.
+         // it is perfectly fine for the connection to not have an attached pool in this scenario.
+         // No HTTP request was ever sent: undo the onAcquire() slot and return the connection
+         // without recording an afterRequest event (which would corrupt the inFlight counter).
          if (connection != null && connection.pool() != null) {
-            connection.pool().release(connection, true, true);
+            connection.cancelAcquire();
+            connection.pool().release(connection, true, false);
          }
       }
    }

--- a/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
+++ b/http/src/main/java/io/hyperfoil/http/steps/HttpRequestContext.java
@@ -41,7 +41,11 @@ class HttpRequestContext implements Session.Resource, ConnectionConsumer {
          this.request.session.proceed();
       } else {
          this.ready = false;
-         if (connection != null) {
+         // Due to Hyperfoil's asynchronous nature, a connection created via `handleNewConnection` can trigger a `pulse`.
+         // During this pulse, a waiting consumer might call `accept` even in the termination phase.
+         // Since the connection is only attached to the pool during `HttpRequest.send()`,
+         // It is perfectly fine for the connection to not have an attached pool in this scenario.
+         if (connection != null && connection.pool() != null) {
             connection.pool().release(connection, true, true);
          }
       }

--- a/http/src/test/java/io/hyperfoil/http/BaseMockConnection.java
+++ b/http/src/test/java/io/hyperfoil/http/BaseMockConnection.java
@@ -88,6 +88,15 @@ public class BaseMockConnection implements HttpConnection {
    }
 
    @Override
+   public void cancelAcquire() {
+   }
+
+   @Override
+   public int pendingRequestCount() {
+      return 0;
+   }
+
+   @Override
    public boolean isAvailable() {
       return false;
    }

--- a/http/src/test/java/io/hyperfoil/http/ConnectionPoolRaceConditionTest.java
+++ b/http/src/test/java/io/hyperfoil/http/ConnectionPoolRaceConditionTest.java
@@ -1,0 +1,146 @@
+package io.hyperfoil.http;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.net.ssl.SSLException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.hyperfoil.api.session.SequenceInstance;
+import io.hyperfoil.api.session.Session;
+import io.hyperfoil.api.statistics.Statistics;
+import io.hyperfoil.core.VertxBaseTest;
+import io.hyperfoil.core.session.SessionFactory;
+import io.hyperfoil.http.api.HttpClientPool;
+import io.hyperfoil.http.api.HttpConnection;
+import io.hyperfoil.http.api.HttpConnectionPool;
+import io.hyperfoil.http.api.HttpMethod;
+import io.hyperfoil.http.api.HttpRequest;
+import io.hyperfoil.http.api.HttpResponseHandlers;
+import io.hyperfoil.http.config.Http;
+import io.hyperfoil.http.config.HttpBuilder;
+import io.hyperfoil.http.config.Protocol;
+import io.hyperfoil.http.connection.HttpClientPoolImpl;
+import io.hyperfoil.http.connection.SharedConnectionPool;
+import io.hyperfoil.http.steps.HttpResponseHandlersImpl;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpServer;
+import io.vertx.junit5.VertxTestContext;
+
+/**
+ * This test extends {@code VertxBaseTest} directly rather than {@code BaseClientTest} because it tests low-level
+ * connection pool internals during session termination, not HTTP request/response flows.
+ */
+public class ConnectionPoolRaceConditionTest extends VertxBaseTest {
+
+   private HttpServer httpServer;
+
+   @BeforeEach
+   public void before(VertxTestContext ctx) {
+      httpServer = vertx.createHttpServer().requestHandler(req -> {
+         req.response().setStatusCode(200);
+         req.response().end("OK");
+      });
+      httpServer.listen(0, "localhost").onComplete(ctx.succeedingThenComplete());
+      cleanup.add(httpServer::close);
+   }
+
+   /**
+    * Test for race condition in connection pool during session termination.
+    * <p>
+    * The race condition occurs when:
+    * 1. A connection is acquired from the pool (inFlight is incremented)
+    * 2. Session termination is triggered, which calls onSessionTryTerminate()
+    * 3. onSessionTryTerminate() sets shouldPulse = false
+    * 4. When pulse() is called, it releases all connections with release(conn, true, false)
+    * - This adds connections to available but does NOT decrement inFlight (afterRequest=false)
+    * 5. If a connection was acquired for a request that's still in-flight, inFlight remains inflated
+    * 6. When the response completes, it calls release(conn, true, true) which adds the connection
+    * to available a second time (ArrayDeque allows duplicates)
+    */
+   @Test
+   public void testConnectionPoolRaceCondition(VertxTestContext ctx) {
+      var checkpoint = ctx.checkpoint();
+      AtomicInteger responseCount = new AtomicInteger();
+      int maxRetries = 5;
+
+      getClientPool(ctx).onComplete(result -> {
+         HttpClientPool client = result.result();
+         Session session = SessionFactory.forTesting();
+         HttpRunData.initForTesting(session);
+         HttpRequest request = HttpRequestPool.get(session).acquire();
+         request.method = HttpMethod.GET;
+         request.path = "/";
+
+         HttpResponseHandlers handlers = HttpResponseHandlersImpl.Builder.forTesting()
+               .onCompletion(s -> {
+                  responseCount.addAndGet(1);
+                  if (responseCount.get() >= 1) {
+                     // Verify the pool state after race condition
+                     // Access the shared connection pool and check stats
+                     SharedConnectionPool sharedPool = (SharedConnectionPool) client.next();
+
+                     // Check that connections are available (they should be released back to pool)
+                     java.util.Collection<HttpConnection> connections = sharedPool.connections();
+                     int availableCount = (int) connections.stream().filter(c -> !c.isClosed()).count();
+                     if (availableCount < 1) {
+                        ctx.failNow("No connections available after race condition - available count: " + availableCount);
+                        return;
+                     }
+
+                     // Check that inFlight count is correct (should be 0 after response completes)
+                     int inFlightCount = sharedPool.inFlightCount();
+                     if (inFlightCount != 0) {
+                        ctx.failNow("inFlight count is inflated: " + inFlightCount + " - race condition detected!");
+                        return;
+                     }
+
+                     checkpoint.flag();
+                  }
+               }).build();
+         HttpConnectionPool pool = client.next();
+         request.start(pool, handlers, new SequenceInstance(), new Statistics(System.currentTimeMillis()));
+         // pool.acquire requires to be running within the event loop
+         // the acquire is called from onComplete callback that can run on different thread
+         // it can fail on CI sometimes. then, we add pool.executor to ensure that it will be running on the event loop.
+         pool.executor().execute(() -> pool.acquire(false, c -> request.send(c, null, true, null)));
+
+         // Trigger session termination to trigger the race condition
+         // This sets shouldPulse = false, and the next pulse() call will release all connections
+         // with release(conn, true, false) which doesn't decrement inFlight
+         session.tryTerminate();
+      });
+
+      // Retry the test multiple times to increase the chance of triggering the race condition
+      for (int i = 0; i < maxRetries; i++) {
+         if (responseCount.get() > 0) {
+            break;
+         }
+      }
+   }
+
+   private Future<HttpClientPool> getClientPool(VertxTestContext ctx) {
+      Http http = HttpBuilder.forTesting().protocol(Protocol.HTTP)
+            .host("localhost").port(httpServer.actualPort())
+            .build(true);
+      try {
+         HttpClientPool client = HttpClientPoolImpl.forTesting(http, 1);
+
+         Promise<HttpClientPool> promise = Promise.promise();
+         client.start(result -> {
+            if (result.failed()) {
+               ctx.failNow(result.cause());
+               promise.fail(result.cause());
+               return;
+            }
+            cleanup.add(client::shutdown);
+            promise.complete(client);
+         });
+         return promise.future();
+      } catch (SSLException e) {
+         return Future.failedFuture(e);
+      }
+   }
+}

--- a/http/src/test/java/io/hyperfoil/http/ConnectionPoolRaceConditionTest.java
+++ b/http/src/test/java/io/hyperfoil/http/ConnectionPoolRaceConditionTest.java
@@ -15,6 +15,7 @@ import io.hyperfoil.api.statistics.Statistics;
 import io.hyperfoil.core.VertxBaseTest;
 import io.hyperfoil.core.session.SessionFactory;
 import io.hyperfoil.http.api.HttpClientPool;
+import io.hyperfoil.http.api.HttpConnection;
 import io.hyperfoil.http.api.HttpMethod;
 import io.hyperfoil.http.api.HttpRequest;
 import io.hyperfoil.http.api.HttpResponseHandlers;
@@ -50,6 +51,15 @@ public class ConnectionPoolRaceConditionTest extends VertxBaseTest {
       cleanup.add(httpServer::close);
    }
 
+   /**
+    * Scenario: duplicate-available-entry bug.
+    *
+    * A connection is on the wire (real HTTP request sent) when onSessionTryTerminate fires.
+    * The !shouldPulse drain must add the connection to pendingDrainConnections rather than
+    * immediately calling release(), because releasePoolAndPulse() will call release() once the
+    * response arrives. Before the fix, the drain called release() unconditionally, causing the
+    * connection to appear twice in the available deque.
+    */
    @Test
    public void testInFlightNotLeakedAfterSessionTerminatePulse(VertxTestContext ctx) {
       var checkpoint = ctx.checkpoint();
@@ -74,6 +84,9 @@ public class ConnectionPoolRaceConditionTest extends VertxBaseTest {
                               .as("available deque should have exactly 1 entry; " +
                                     "a count of 2 means the !shouldPulse path created a duplicate")
                               .isEqualTo(1);
+                        assertThat(pool.inFlightCount())
+                              .as("pool-level inFlight counter must be 0 after response completes")
+                              .isEqualTo(0);
 
                         checkpoint.flag();
                      }));
@@ -83,10 +96,139 @@ public class ConnectionPoolRaceConditionTest extends VertxBaseTest {
             pool.acquire(false, c -> {
                request.send(c, null, true, null);
 
+               // Once the request is on the wire, simulate session termination, then let the
+               // server respond. The response triggers releasePoolAndPulse() which must find
+               // shouldPulse still false (deferred via pendingDrainConnections) and restore it.
                pendingRequest.thenAccept(req -> {
                   pool.executor().execute(() -> {
                      pool.onSessionTryTerminate();
                      pool.pulse();
+                     req.response().setStatusCode(200).end("OK");
+                  });
+               });
+            });
+         });
+      });
+   }
+
+   /**
+    * Scenario: orphaned-acquisition drain path.
+    *
+    * A connection is acquired (onAcquire called, aboutToSend == 1) but the session is reset
+    * before request() is ever called — so no HTTP bytes go on the wire. When onSessionTryTerminate
+    * fires, the drain must detect this via pendingRequestCount() == 0 && inFlight() > 0, cancel
+    * the orphaned slot with cancelAcquire(), and return the connection as available. Pool-level
+    * inFlight and usedConnections counters must both reach 0.
+    */
+   @Test
+   public void testOrphanedAcquisitionDrainedWithoutCounterCorruption(VertxTestContext ctx) {
+      var checkpoint = ctx.checkpoint();
+
+      getClientPool(ctx).onComplete(result -> {
+         if (result.failed())
+            return;
+         HttpClientPool client = result.result();
+
+         SharedConnectionPool pool = (SharedConnectionPool) client.next();
+         pool.executor().execute(() -> {
+            // Acquire the connection but never call request.send() — this leaves aboutToSend == 1
+            // with no bytes on the wire, exactly the orphaned-acquisition state.
+            pool.acquire(false, (HttpConnection conn) -> {
+               // Verify the connection is indeed in the orphaned state before the drain.
+               assertThat(conn.pendingRequestCount())
+                     .as("no HTTP request sent yet, pendingRequestCount must be 0")
+                     .isEqualTo(0);
+               assertThat(conn.inFlight())
+                     .as("onAcquire incremented aboutToSend, so inFlight must be 1")
+                     .isEqualTo(1);
+
+               // Simulate session termination while the acquisition slot is still open.
+               pool.onSessionTryTerminate();
+               pool.pulse();
+
+               ctx.verify(() -> {
+                  assertThat(pool.availableCount())
+                        .as("connection must be returned to the available deque after orphaned drain")
+                        .isEqualTo(1);
+                  assertThat(pool.inFlightCount())
+                        .as("pool inFlight counter must be 0 — cancelAcquire undoes the acquireNow increment")
+                        .isEqualTo(0);
+                  assertThat(conn.inFlight())
+                        .as("connection-level inFlight must be 0 after cancelAcquire")
+                        .isEqualTo(0);
+               });
+
+               checkpoint.flag();
+            });
+         });
+      });
+   }
+
+   /**
+    * Scenario: deferred-drain lifecycle — shouldPulse stays false until the last in-flight
+    * connection responds, then restores to true so waiting consumers can proceed.
+    *
+    * One connection sends a real request (parked at the server). While the request is on the
+    * wire, onSessionTryTerminate fires: shouldPulse goes false and the connection is added to
+    * pendingDrainConnections. A second acquire() call joins the waiting queue. Once the server
+    * responds, release() removes the connection from pendingDrainConnections, restores
+    * shouldPulse, and calls pulse() to serve the waiting consumer — without creating duplicate
+    * entries in the available deque.
+    */
+   @Test
+   public void testDeferredDrainRestoresShouldPulseAndServesWaitingConsumer(VertxTestContext ctx) {
+      // Two checkpoints: one for the in-flight response, one for the waiting consumer.
+      var inFlightCheckpoint = ctx.checkpoint();
+      var waitingCheckpoint = ctx.checkpoint();
+
+      getClientPool(ctx).onComplete(result -> {
+         if (result.failed())
+            return;
+         HttpClientPool client = result.result();
+
+         SharedConnectionPool pool = (SharedConnectionPool) client.next();
+         pool.executor().execute(() -> {
+            Session session = SessionFactory.forTesting();
+            HttpRunData.initForTesting(session);
+            HttpRequest request = HttpRequestPool.get(session).acquire();
+            request.method = HttpMethod.GET;
+            request.path = "/";
+
+            HttpResponseHandlers handlers = HttpResponseHandlersImpl.Builder.forTesting()
+                  .onCompletion(s -> {
+                     // The response has arrived and releasePoolAndPulse() has fired, which:
+                     //   1. called release() → shouldPulse restored to true
+                     //   2. called pulse()   → waiting consumer served, connection re-acquired
+                     // By the time onCompletion runs the waiting consumer already holds the
+                     // connection, so inFlight == 1 and available == 0. We only flag here to
+                     // confirm the response path completed; counter correctness is covered by
+                     // testInFlightNotLeakedAfterSessionTerminatePulse.
+                     pool.executor().execute(() -> inFlightCheckpoint.flag());
+                  }).build();
+
+            request.start(pool, handlers, new SequenceInstance(), new Statistics(System.currentTimeMillis()));
+            pool.acquire(false, c -> {
+               request.send(c, null, true, null);
+
+               pendingRequest.thenAccept(req -> {
+                  pool.executor().execute(() -> {
+                     // Session terminates while the request is on the wire.
+                     pool.onSessionTryTerminate();
+                     pool.pulse();
+
+                     // A second consumer joins the waiting queue while shouldPulse == false.
+                     // It must be served once the in-flight response arrives and release()
+                     // restores shouldPulse.
+                     pool.acquire(false, waiting -> ctx.verify(() -> {
+                        assertThat(waiting)
+                              .as("waiting consumer must receive a connection after shouldPulse is restored")
+                              .isNotNull();
+                        // Return it so the pool stays consistent.
+                        pool.release(waiting, true, false);
+                        waitingCheckpoint.flag();
+                     }));
+
+                     // Unblock the server — triggers releasePoolAndPulse() which restores shouldPulse.
                      req.response().setStatusCode(200).end("OK");
                   });
                });

--- a/http/src/test/java/io/hyperfoil/http/ConnectionPoolRaceConditionTest.java
+++ b/http/src/test/java/io/hyperfoil/http/ConnectionPoolRaceConditionTest.java
@@ -1,6 +1,8 @@
 package io.hyperfoil.http;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CompletableFuture;
 
 import javax.net.ssl.SSLException;
 
@@ -13,8 +15,6 @@ import io.hyperfoil.api.statistics.Statistics;
 import io.hyperfoil.core.VertxBaseTest;
 import io.hyperfoil.core.session.SessionFactory;
 import io.hyperfoil.http.api.HttpClientPool;
-import io.hyperfoil.http.api.HttpConnection;
-import io.hyperfoil.http.api.HttpConnectionPool;
 import io.hyperfoil.http.api.HttpMethod;
 import io.hyperfoil.http.api.HttpRequest;
 import io.hyperfoil.http.api.HttpResponseHandlers;
@@ -27,103 +27,78 @@ import io.hyperfoil.http.steps.HttpResponseHandlersImpl;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.junit5.VertxTestContext;
 
-/**
- * This test extends {@code VertxBaseTest} directly rather than {@code BaseClientTest} because it tests low-level
- * connection pool internals during session termination, not HTTP request/response flows.
- */
 public class ConnectionPoolRaceConditionTest extends VertxBaseTest {
 
+   /** Holds the first server-side request so the test can delay and then release it. */
+   private final CompletableFuture<HttpServerRequest> pendingRequest = new CompletableFuture<>();
    private HttpServer httpServer;
 
    @BeforeEach
    public void before(VertxTestContext ctx) {
       httpServer = vertx.createHttpServer().requestHandler(req -> {
-         req.response().setStatusCode(200);
-         req.response().end("OK");
+         // Park the first request; the test will unblock it after the race is set up.
+         if (!pendingRequest.isDone()) {
+            pendingRequest.complete(req);
+         } else {
+            req.response().setStatusCode(200).end("OK");
+         }
       });
       httpServer.listen(0, "localhost").onComplete(ctx.succeedingThenComplete());
       cleanup.add(httpServer::close);
    }
 
-   /**
-    * Test for race condition in connection pool during session termination.
-    * <p>
-    * The race condition occurs when:
-    * 1. A connection is acquired from the pool (inFlight is incremented)
-    * 2. Session termination is triggered, which calls onSessionTryTerminate()
-    * 3. onSessionTryTerminate() sets shouldPulse = false
-    * 4. When pulse() is called, it releases all connections with release(conn, true, false)
-    * - This adds connections to available but does NOT decrement inFlight (afterRequest=false)
-    * 5. If a connection was acquired for a request that's still in-flight, inFlight remains inflated
-    * 6. When the response completes, it calls release(conn, true, true) which adds the connection
-    * to available a second time (ArrayDeque allows duplicates)
-    */
    @Test
-   public void testConnectionPoolRaceCondition(VertxTestContext ctx) {
+   public void testInFlightNotLeakedAfterSessionTerminatePulse(VertxTestContext ctx) {
       var checkpoint = ctx.checkpoint();
-      AtomicInteger responseCount = new AtomicInteger();
-      int maxRetries = 5;
 
       getClientPool(ctx).onComplete(result -> {
+         if (result.failed())
+            return;
          HttpClientPool client = result.result();
-         Session session = SessionFactory.forTesting();
-         HttpRunData.initForTesting(session);
-         HttpRequest request = HttpRequestPool.get(session).acquire();
-         request.method = HttpMethod.GET;
-         request.path = "/";
 
-         HttpResponseHandlers handlers = HttpResponseHandlersImpl.Builder.forTesting()
-               .onCompletion(s -> {
-                  responseCount.addAndGet(1);
-                  if (responseCount.get() >= 1) {
-                     // Verify the pool state after race condition
-                     // Access the shared connection pool and check stats
-                     SharedConnectionPool sharedPool = (SharedConnectionPool) client.next();
+         SharedConnectionPool pool = (SharedConnectionPool) client.next();
+         pool.executor().execute(() -> {
+            Session session = SessionFactory.forTesting();
+            HttpRunData.initForTesting(session);
+            HttpRequest request = HttpRequestPool.get(session).acquire();
+            request.method = HttpMethod.GET;
+            request.path = "/";
 
-                     // Check that connections are available (they should be released back to pool)
-                     java.util.Collection<HttpConnection> connections = sharedPool.connections();
-                     int availableCount = (int) connections.stream().filter(c -> !c.isClosed()).count();
-                     if (availableCount < 1) {
-                        ctx.failNow("No connections available after race condition - available count: " + availableCount);
-                        return;
-                     }
+            HttpResponseHandlers handlers = HttpResponseHandlersImpl.Builder.forTesting()
+                  .onCompletion(s -> {
+                     pool.executor().execute(() -> ctx.verify(() -> {
+                        assertThat(pool.availableCount())
+                              .as("available deque should have exactly 1 entry; " +
+                                    "a count of 2 means the !shouldPulse path created a duplicate")
+                              .isEqualTo(1);
 
-                     // Check that inFlight count is correct (should be 0 after response completes)
-                     int inFlightCount = sharedPool.inFlightCount();
-                     if (inFlightCount != 0) {
-                        ctx.failNow("inFlight count is inflated: " + inFlightCount + " - race condition detected!");
-                        return;
-                     }
+                        checkpoint.flag();
+                     }));
+                  }).build();
 
-                     checkpoint.flag();
-                  }
-               }).build();
-         HttpConnectionPool pool = client.next();
-         request.start(pool, handlers, new SequenceInstance(), new Statistics(System.currentTimeMillis()));
-         // pool.acquire requires to be running within the event loop
-         // the acquire is called from onComplete callback that can run on different thread
-         // it can fail on CI sometimes. then, we add pool.executor to ensure that it will be running on the event loop.
-         pool.executor().execute(() -> pool.acquire(false, c -> request.send(c, null, true, null)));
+            request.start(pool, handlers, new SequenceInstance(), new Statistics(System.currentTimeMillis()));
+            pool.acquire(false, c -> {
+               request.send(c, null, true, null);
 
-         // Trigger session termination to trigger the race condition
-         // This sets shouldPulse = false, and the next pulse() call will release all connections
-         // with release(conn, true, false) which doesn't decrement inFlight
-         session.tryTerminate();
+               pendingRequest.thenAccept(req -> {
+                  pool.executor().execute(() -> {
+                     pool.onSessionTryTerminate();
+                     pool.pulse();
+                     req.response().setStatusCode(200).end("OK");
+                  });
+               });
+            });
+         });
       });
-
-      // Retry the test multiple times to increase the chance of triggering the race condition
-      for (int i = 0; i < maxRetries; i++) {
-         if (responseCount.get() > 0) {
-            break;
-         }
-      }
    }
 
    private Future<HttpClientPool> getClientPool(VertxTestContext ctx) {
       Http http = HttpBuilder.forTesting().protocol(Protocol.HTTP)
             .host("localhost").port(httpServer.actualPort())
+            .sharedConnections(1)
             .build(true);
       try {
          HttpClientPool client = HttpClientPoolImpl.forTesting(http, 1);

--- a/http/src/test/java/io/hyperfoil/http/ConnectionPoolRaceConditionTest.java
+++ b/http/src/test/java/io/hyperfoil/http/ConnectionPoolRaceConditionTest.java
@@ -237,6 +237,50 @@ public class ConnectionPoolRaceConditionTest extends VertxBaseTest {
       });
    }
 
+   @Test
+   public void testAcceptNullRequestLeaksPoolInFlight(VertxTestContext ctx) {
+      var checkpoint = ctx.checkpoint();
+
+      getClientPool(ctx).onComplete(result -> {
+         if (result.failed())
+            return;
+         HttpClientPool client = result.result();
+
+         SharedConnectionPool pool = (SharedConnectionPool) client.next();
+         pool.executor().execute(() -> {
+            Session session = SessionFactory.forTesting();
+            HttpRunData.initForTesting(session);
+
+            // Acquire the only connection so the pool is exhausted
+            pool.acquire(false, (HttpConnection firstConn) -> {
+
+               // Mimic real-world initialization where the connection has been attached to a pool
+               firstConn.attach(pool);
+
+               // Put a consumer in the waiting queue that mimics
+               // HttpRequestContext.accept() when request==null
+               pool.acquire(false, (HttpConnection conn) -> {
+                  if (conn != null && conn.pool() != null) {
+                     conn.pool().cancelAcquire(conn);
+                  }
+
+                  ctx.verify(() -> {
+                     assertThat(pool.inFlightCount())
+                           .as("pool inFlight should be 0 — cancelAcquire undoes conn-level but not pool-level")
+                           .isEqualTo(0);
+                  });
+                  checkpoint.flag();
+               });
+
+               // Release firstConn to trigger pulse() which pops the waiting consumer
+               firstConn.cancelAcquire();
+               pool.release(firstConn, true, true);
+               pool.pulse();
+            });
+         });
+      });
+   }
+
    private Future<HttpClientPool> getClientPool(VertxTestContext ctx) {
       Http http = HttpBuilder.forTesting().protocol(Protocol.HTTP)
             .host("localhost").port(httpServer.actualPort())

--- a/http/src/test/resources/log4j2.xml
+++ b/http/src/test/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration name="CommandLineConfig">
+    <Appenders>
+        <Console name="STDOUT">
+            <PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p (%t) [%c{1.}] %m%throwable{10}%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="io.hyperfoil.http" level="DEBUG" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+        <Root level="INFO">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/BaseWrkBenchmarkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/BaseWrkBenchmarkTest.java
@@ -36,6 +36,11 @@ public abstract class BaseWrkBenchmarkTest extends BaseBenchmarkTest {
       router.route("/highway").handler(ctx -> {
          ctx.response().end("highway");
       });
+      router.route("/500ms").handler(ctx -> {
+         ctx.vertx().setTimer(500, id -> {
+            ctx.response().end("500ms!");
+         });
+      });
       router.route("/1s").handler(ctx -> {
          ctx.vertx().setTimer(1_000, id -> {
             ctx.response().end("1s");

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
@@ -129,13 +129,17 @@ public class WrkTest extends BaseWrkBenchmarkTest {
       Wrk2.Wrk2Command wrk2Command = (Wrk2.Wrk2Command) processedCommand.getCommand();
       WrkAbstract.WrkCommandResult wrkCommandResult = wrk2Command.getWrkCommandResult();
 
-      // At 20K rate with 10 connections against /unpredictable, the test phase runs but
-      // all sessions block waiting for connections and time out — no test-phase stats are produced.
-      // The command returns FAILURE because it cannot find test-phase statistics to print.
-      assertEquals(CommandResult.FAILURE.getResultValue(), result);
+      assertEquals(CommandResult.SUCCESS.getResultValue(), result);
       assertFalse(wrkCommandResult.getRequestStatisticsResponse().statistics.isEmpty());
+
+      boolean failedSLA = false;
       for (RequestStats requestStats : wrkCommandResult.getRequestStatisticsResponse().statistics) {
-         assertFalse(requestStats.failedSLAs.isEmpty());
+         failedSLA = !requestStats.failedSLAs.isEmpty();
+         if (failedSLA) {
+            break;
+         }
       }
+      // we are expecting at least one failed SLA because of the high rate
+      assertTrue(failedSLA);
    }
 }

--- a/test-suite/src/test/java/io/hyperfoil/scenario/WrkScenarioTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/scenario/WrkScenarioTest.java
@@ -40,7 +40,6 @@ public class WrkScenarioTest extends BaseWrkBenchmarkTest {
       Map<String, Map<String, StatisticsSnapshot>> phaseStats = statisticsConsumer.phaseStats();
       Assertions.assertTrue(phaseStats.containsKey("calibration"), "Stats must have values for the 'calibration' phase");
       Assertions.assertTrue(phaseStats.containsKey("test"), "Stats must have values for the 'test' phase");
-      System.out.println(phaseStats);
    }
 
    @Test

--- a/test-suite/src/test/java/io/hyperfoil/scenario/WrkScenarioTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/scenario/WrkScenarioTest.java
@@ -34,6 +34,16 @@ public class WrkScenarioTest extends BaseWrkBenchmarkTest {
    protected final Logger log = LogManager.getLogger(getClass());
 
    @Test
+   public void wrk2SuperSlowServer() throws URISyntaxException {
+      String url = "localhost:" + httpServer.actualPort() + "/500ms";
+      BaseScenarioTest.TestStatistics statisticsConsumer = runWrk2Scenario(6, 20, url, 50000, 2, 10, 2);
+      Map<String, Map<String, StatisticsSnapshot>> phaseStats = statisticsConsumer.phaseStats();
+      Assertions.assertTrue(phaseStats.containsKey("calibration"), "Stats must have values for the 'calibration' phase");
+      Assertions.assertTrue(phaseStats.containsKey("test"), "Stats must have values for the 'test' phase");
+      System.out.println(phaseStats);
+   }
+
+   @Test
    public void testWrk() throws URISyntaxException {
 
       String url = "localhost:" + httpServer.actualPort() + "/highway";


### PR DESCRIPTION
- Fixes a NullPointerException in HttpRequestContext where `this.request` is null when acquiring a connection.
- Stops the connection pool pulse loop when a phase is terminating by introducing `Session.tryTerminate()`.
- Prevents connection leaks during termination by clearing the waiting queue and releasing active connections back to the pool.

Fixes: 
- https://github.com/Hyperfoil/Hyperfoil/issues/643
- https://github.com/Hyperfoil/Hyperfoil/issues/642
- https://github.com/Hyperfoil/Hyperfoil/issues/638

Stacktrace before the fix
```
09:21:46,049 WARN  (epollEventLoopGroup-2-1) [i.h.h.c.Http1xConnection] Exception in Http1xConnection{/127.0.0.1:46166 -> localhost/127.0.0.1:41281, status=OPEN, size=0+1:[]}java.lang.NullPointerException: Cannot read field "session" because "this.request" is null
	at io.hyperfoil.http.steps.HttpRequestContext.accept(HttpRequestContext.java:37)
	at io.hyperfoil.http.connection.SharedConnectionPool.pulse(SharedConnectionPool.java:203)
	at io.hyperfoil.http.connection.SharedConnectionPool.handleNewConnection(SharedConnectionPool.java:325)
	at io.hyperfoil.http.connection.Http1xConnection.checkActivated(Http1xConnection.java:75)
	at io.hyperfoil.http.connection.Http1xConnection.channelActive(Http1xConnection.java:69)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelActive(AbstractChannelHandlerContext.java:260)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelActive(AbstractChannelHandlerContext.java:238)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelActive(AbstractChannelHandlerContext.java:231)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelActive(DefaultChannelPipeline.java:1345)
```