### PR TITLE
Include the BufferedReader in the try-with-resources statement together with the underlying InputStream

### DIFF
--- a/core/src/main/java/io/hyperfoil/core/generators/RandomCsvRowStep.java
+++ b/core/src/main/java/io/hyperfoil/core/generators/RandomCsvRowStep.java
@@ -96,8 +96,8 @@ public class RandomCsvRowStep implements Step {
          }
          assert next == srcIndex.length;
 
-         try (InputStream inputStream = Locator.current().benchmark().data().readFile(file)) {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+         try (InputStream inputStream = Locator.current().benchmark().data().readFile(file);
+               BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
             ArrayList<String[]> records = new ArrayList<>();
             String line;
             ArrayList<String> currentRecord = new ArrayList<>();


### PR DESCRIPTION
Include the BufferedReader in the try-with-resources statement together with the underlying InputStream