### PR TITLE
Add invalid column to stats command

### DIFF
--- a/cli/src/main/java/io/hyperfoil/cli/commands/Stats.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/Stats.java
@@ -36,6 +36,7 @@ public class Stats extends BaseRunIdCommand {
          .columnNanos("p99", r -> r.summary.percentileResponseTime.get(99d))
          .columnNanos("p99.9", r -> r.summary.percentileResponseTime.get(99.9))
          .columnNanos("p99.99", r -> r.summary.percentileResponseTime.get(99.99))
+         .columnInt("INVALID", r -> r.summary.invalid)
          .columnInt("TIMEOUTS", r -> r.summary.requestTimeouts)
          .columnInt("ERRORS", r -> r.summary.connectionErrors + r.summary.internalErrors)
          .columnNanos("BLOCKED", r -> r.summary.blockedTime);


### PR DESCRIPTION
Add an invalid column to the stats command
```
Terminated: 2026/06/25 12:47:13.061
Run statistics persisted in the local filesystem
Total stats from run 0005
PHASE     METRIC        THROUGHPUT    REQUESTS  MEAN     STD_DEV   MAX        p50        p90      p99       p99.9      p99.99     INVALID  TIMEOUTS  ERRORS  BLOCKED    2xx    3xx  4xx  5xx  CACHE
warmup    getAllFruits  495.24 req/s     60955  1.61 ms   6.92 ms  165.68 ms  716.80 μs  2.15 ms  12.19 ms  147.85 ms  158.33 ms     1422         0    1422       0 ns  59533    0    0    0      0
loadTest  getAllFruits  491.16 req/s     15185  2.77 ms  13.69 ms  154.14 ms  708.61 μs  2.01 ms  81.26 ms  152.04 ms  154.14 ms      350         0     350  223.94 ms  14835    0    0    0      0
loadTest/getAllFruits: Progress was blocked waiting for a free connection. Hint: increase http.sharedConnections.
loadTest/getAllFruits: Progress was blocked waiting for a free connection. Hint: increase http.sharedConnections.
Report written to /home/dlovison/spring-quarkus-perf-comparison/logs/hyperfoil/spring4-jvm-0/0005.html
```
It will match the HTML report
<img width="1905" height="176" alt="image" src="https://github.com/user-attachments/assets/6fdd7e6b-ee6f-4acb-8422-3a31baa8e3f3" />
