### PR TITLE
[#847] Support clustered benchmarks via CLI

### DIFF
--- a/api/src/main/java/io/hyperfoil/internal/Controller.java
+++ b/api/src/main/java/io/hyperfoil/internal/Controller.java
@@ -23,6 +23,6 @@ public interface Controller {
    void stop();
 
    interface Factory {
-      Controller start(Path rootDir);
+      Controller start(Path rootDir, boolean clustered);
    }
 }

--- a/cli/src/main/java/io/hyperfoil/cli/commands/BaseStandaloneCommand.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/BaseStandaloneCommand.java
@@ -63,7 +63,7 @@ public abstract class BaseStandaloneCommand {
          cr = runtime.build();
          try {
             // start the local in-vm controller server
-            cr.executeCommand("start-local --quiet");
+            cr.executeCommand(startLocalCommand());
             // As -H option could contain a whitespace we have to either escape the space or quote the argument.
             // However, quoting would not work well if the argument contains a quote.
             String optionsCollected = Stream.of(args).map(arg -> arg.replaceAll(" ", "\\\\ ")).collect(Collectors.joining(" "));
@@ -89,6 +89,10 @@ public abstract class BaseStandaloneCommand {
       }
 
       return result == null ? CommandResult.FAILURE.getResultValue() : result.getResultValue();
+   }
+
+   protected String startLocalCommand() {
+      return "start-local --quiet";
    }
 
    /**

--- a/cli/src/main/java/io/hyperfoil/cli/commands/LoadAndRun.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/LoadAndRun.java
@@ -1,6 +1,8 @@
 package io.hyperfoil.cli.commands;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
@@ -12,9 +14,18 @@ import io.hyperfoil.cli.context.HyperfoilCommandInvocation;
 public class LoadAndRun extends BaseStandaloneCommand {
 
    private static final String CMD = "run";
+   private static final String CLUSTERED = "--clustered";
+
+   private final boolean clustered;
+
+   public LoadAndRun(boolean clustered) {
+      this.clustered = clustered;
+   }
 
    public static void main(String[] args) {
-      LoadAndRun lr = new LoadAndRun();
+      boolean clustered = Arrays.asList(args).contains(CLUSTERED);
+      args = Stream.of(args).filter(s -> !CLUSTERED.equals(s)).toArray(String[]::new);
+      LoadAndRun lr = new LoadAndRun(clustered);
       lr.exec(args);
    }
 
@@ -31,6 +42,14 @@ public class LoadAndRun extends BaseStandaloneCommand {
    @Override
    protected String getCommandName() {
       return CMD;
+   }
+
+   @Override
+   protected String startLocalCommand() {
+      if (!clustered)
+         return super.startLocalCommand();
+
+      return super.startLocalCommand() + " " + CLUSTERED;
    }
 
    @CommandDefinition(name = "run", description = "Load and start a benchmark on Hyperfoil controller server, the argument can be the benchmark definition directly.")

--- a/cli/src/main/java/io/hyperfoil/cli/commands/StartLocal.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/StartLocal.java
@@ -31,6 +31,9 @@ public class StartLocal extends ServerCommand {
    @Option(shortName = 'q', description = "Do not print anything on output in this command.", hasValue = false)
    private boolean quiet;
 
+   @Option(name = "clustered", description = "Whether this node will manage a clustered benchmark", hasValue = false)
+   private boolean clustered;
+
    @Argument(description = "Root directory used for the controller.")
    private Resource rootDir;
 
@@ -66,7 +69,7 @@ public class StartLocal extends ServerCommand {
             System.setProperty(Properties.CONTROLLER_LOG_LEVEL, logLevel);
          }
          reconfigureLogging(invocation);
-         Controller controller = factory.start(rootDir == null ? null : ((FileResource) rootDir).getFile().toPath());
+         Controller controller = factory.start(rootDir == null ? null : ((FileResource) rootDir).getFile().toPath(), clustered);
          ctx.setLocalControllerHost(controller.host());
          ctx.setLocalControllerPort(controller.port());
          if (!quiet) {

--- a/clustering/src/main/java/io/hyperfoil/LocalController.java
+++ b/clustering/src/main/java/io/hyperfoil/LocalController.java
@@ -2,6 +2,7 @@ package io.hyperfoil;
 
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.kohsuke.MetaInfServices;
 
@@ -10,6 +11,7 @@ import io.hyperfoil.clustering.ControllerVerticle;
 import io.hyperfoil.internal.Controller;
 import io.hyperfoil.internal.Properties;
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 
@@ -17,11 +19,13 @@ public class LocalController implements Controller {
    private final Vertx vertx;
    private final String host;
    private final int port;
+   private final boolean clustered;
 
-   public LocalController(Vertx vertx, String host, int port) {
+   public LocalController(Vertx vertx, String host, int port, boolean clustered) {
       this.vertx = vertx;
       this.host = host;
       this.port = port;
+      this.clustered = clustered;
    }
 
    @Override
@@ -37,7 +41,8 @@ public class LocalController implements Controller {
    @Override
    public void stop() {
       CompletableFuture<Void> stopFuture = new CompletableFuture<>();
-      vertx.close().onComplete(result -> {
+      Future<Void> f = clustered ? Hyperfoil.shutdownVertx(vertx) : vertx.close();
+      f.onComplete(result -> {
          if (result.succeeded()) {
             stopFuture.complete(null);
          } else {
@@ -50,19 +55,23 @@ public class LocalController implements Controller {
    @MetaInfServices(Controller.Factory.class)
    public static class Factory implements Controller.Factory {
       @Override
-      public Controller start(Path rootDir) {
+      public Controller start(Path rootDir, boolean clustered) {
          if (rootDir != null) {
             // TODO: setting property could break test suite but it's that easy to override all uses of Controller.ROOT_DIR
             System.setProperty(Properties.ROOT_DIR, rootDir.toFile().getAbsolutePath());
          } else {
             rootDir = Controller.DEFAULT_ROOT_DIR;
          }
+         Vertx vertx = resolveVertex(clustered).toCompletableFuture().join();
+         String host = resolveLocalHostIp(clustered);
          JsonObject config = new JsonObject();
          config.put(Properties.CONTROLLER_LOG, rootDir.resolve("hyperfoil.local.log").toFile().getAbsolutePath());
-         config.put(Properties.CONTROLLER_HOST, "127.0.0.1");
+         config.put(Properties.CONTROLLER_HOST, host);
          config.put(Properties.CONTROLLER_PORT, 0);
-         Vertx vertx = Vertx.vertx();
-         Codecs.register(vertx);
+
+         if (!clustered)
+            Codecs.register(vertx);
+
          Hyperfoil.ensureNettyResourceLeakDetection();
          CompletableFuture<Integer> completion = new CompletableFuture<>();
          ControllerVerticle controller = new ControllerVerticle();
@@ -73,7 +82,20 @@ public class LocalController implements Controller {
                completion.completeExceptionally(event.cause());
             }
          });
-         return new LocalController(vertx, "127.0.0.1", completion.join());
+         return new LocalController(vertx, host, completion.join(), clustered);
+      }
+
+      private CompletionStage<Vertx> resolveVertex(boolean clustered) {
+         if (!clustered)
+            return CompletableFuture.completedFuture(Vertx.vertx());
+
+         return Hyperfoil.clusteredVertx(true).toCompletionStage();
+      }
+
+      private String resolveLocalHostIp(boolean clustered) {
+         return clustered
+               ? System.getProperty(Properties.CONTROLLER_CLUSTER_IP, "127.0.0.1")
+               : "127.0.0.1";
       }
    }
 }

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/clustering/ClusteredLoadAndRunTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/clustering/ClusteredLoadAndRunTest.java
@@ -1,0 +1,29 @@
+package io.hyperfoil.benchmark.clustering;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.aesh.command.CommandResult;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import io.hyperfoil.benchmark.BaseBenchmarkTest;
+import io.hyperfoil.cli.commands.LoadAndRun;
+import io.hyperfoil.internal.Properties;
+
+@Tag("io.hyperfoil.test.Benchmark")
+public class ClusteredLoadAndRunTest extends BaseBenchmarkTest {
+
+   @Test
+   public void testClusteredBenchmarkWithAgents() {
+      System.setProperty(Properties.CONTROLLER_CLUSTER_IP, "localhost");
+      System.setProperty(Properties.CONTROLLER_HOST, "localhost");
+      System.setProperty(Properties.CONTROLLER_PORT, "0");
+      System.setProperty("jgroups.bind.address", "127.0.0.1");
+      System.setProperty("jgroups.join_timeout", "15000");
+
+      String benchmark = getBenchmarkPath("scenarios/clusteredHttp.hf.yaml");
+      LoadAndRun cmd = new LoadAndRun(true);
+      int result = cmd.exec(new String[] { benchmark, "-PSERVER_PORT=" + httpServer.actualPort() });
+      assertEquals(CommandResult.SUCCESS.getResultValue(), result);
+   }
+}

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/RunTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/RunTest.java
@@ -21,22 +21,30 @@ public class RunTest extends BaseBenchmarkTest {
    @Test
    public void testRun() {
       String benchmark = getBenchmarkPath("scenarios/httpRequestParameterized.hf.yaml");
-      LoadAndRun cmd = new LoadAndRun();
+      LoadAndRun cmd = new LoadAndRun(false);
       int result = cmd.exec(new String[] { benchmark, "-PSERVER_PORT=" + httpServer.actualPort() });
       assertEquals(CommandResult.SUCCESS.getResultValue(), result);
    }
 
    @Test
    public void testRunMissingBenchmarkArg() {
-      LoadAndRun cmd = new LoadAndRun();
+      LoadAndRun cmd = new LoadAndRun(false);
       int result = cmd.exec(new String[] {});
       assertEquals(CommandResult.FAILURE.getResultValue(), result);
    }
 
    @Test
    public void testRunBenchmarkNotFound() {
-      LoadAndRun cmd = new LoadAndRun();
+      LoadAndRun cmd = new LoadAndRun(false);
       int result = cmd.exec(new String[] { "not-found.hf.yaml" });
+      assertEquals(CommandResult.FAILURE.getResultValue(), result);
+   }
+
+   @Test
+   public void testRunClusteredRejectsBenchmarkWithoutAgents() {
+      String benchmark = getBenchmarkPath("scenarios/httpRequestParameterized.hf.yaml");
+      LoadAndRun cmd = new LoadAndRun(true);
+      int result = cmd.exec(new String[] { benchmark, "-PSERVER_PORT=" + httpServer.actualPort() });
       assertEquals(CommandResult.FAILURE.getResultValue(), result);
    }
 }

--- a/test-suite/src/test/resources/scenarios/clusteredHttp.hf.yaml
+++ b/test-suite/src/test/resources/scenarios/clusteredHttp.hf.yaml
@@ -1,0 +1,16 @@
+name: clustered-test
+agents:
+  agent0: localhost
+http:
+  host: http://localhost
+  port: !param SERVER_PORT
+phases:
+- test:
+    atOnce:
+      users: 1
+      duration: 1s
+      scenario:
+        initialSequences:
+        - test:
+          - httpRequest:
+              GET: /


### PR DESCRIPTION
* Include the `--clustered` flag when running a clustered benchmark with the CLI.

Closes #847

## Changes proposed

Included a `--clustered` flag to pass along to indicate whether it is running a benchmark as clustered or in-VM. Without the flag, we would need to parse the provided benchmark file to identify whether it has the agents. I think just passing the flag is simpler. It moves the complexity to the user, though.
