### PR TITLE
fix(core): calculate throughput using request fired time instead of scheduled time

### DIFF
--- a/api/src/main/java/io/hyperfoil/api/config/StartTimeSource.java
+++ b/api/src/main/java/io/hyperfoil/api/config/StartTimeSource.java
@@ -21,6 +21,7 @@ public interface StartTimeSource {
     * @param target a pre-allocated {@code long[]} buffer to store [millis, nanos]
     */
    default void createStartTimestamp(Session session, boolean useSessionStartTime, long[] target) {
+      assert target.length == 2;
       if (useSessionStartTime) {
          long sessionStartTime = session.scheduledStartTimestamp();
          long sessionStartNanoTime = session.scheduledStartNanoTime();
@@ -38,4 +39,8 @@ public interface StartTimeSource {
    long getStartTimestampMillis(Session session);
 
    long getStartTimestampNanos(Session session);
+
+   long getFiredTimestampMillis(Session session);
+
+   void setFiredTimestampMillis(Session session);
 }

--- a/api/src/main/java/io/hyperfoil/api/connection/Request.java
+++ b/api/src/main/java/io/hyperfoil/api/connection/Request.java
@@ -26,6 +26,7 @@ public abstract class Request implements Callable<Void>, GenericFutureListener<F
    private final long[] timestamps = new long[2];
    private long startTimestampMillis;
    private long startTimestampNanos;
+   private long firedTimestampMillis;
    private SequenceInstance sequence;
    private SequenceInstance completionSequence;
    private Statistics statistics;
@@ -145,6 +146,15 @@ public abstract class Request implements Callable<Void>, GenericFutureListener<F
 
    public long startTimestampNanos() {
       return startTimestampNanos;
+   }
+
+   public long firedTimestampMillis() {
+      return this.firedTimestampMillis;
+   }
+
+   @Override
+   public void setFiredTimestampMillis(Session session) {
+      this.firedTimestampMillis = System.currentTimeMillis();
    }
 
    public void setTimeout(long timeout, TimeUnit timeUnit) {

--- a/api/src/main/java/io/hyperfoil/api/statistics/Statistics.java
+++ b/api/src/main/java/io/hyperfoil/api/statistics/Statistics.java
@@ -132,7 +132,8 @@ public class Statistics {
    public void incrementBlockedTime(StartTimeSource source, long blockedTime, Session session) {
       long criticalValueAtEnter = recordingPhaser.writerCriticalSectionEnter();
       try {
-         StatisticsSnapshot active = active(source, session);
+         // it can be or not fired. track always as intended time
+         StatisticsSnapshot active = active(source.getStartTimestampMillis(session));
          active.blockedTime += blockedTime;
       } finally {
          recordingPhaser.writerCriticalSectionExit(criticalValueAtEnter);
@@ -259,15 +260,19 @@ public class Statistics {
    }
 
    private StatisticsSnapshot active(StartTimeSource source, Session session) {
-      long startTimestampMillis = source.getStartTimestampMillis(session);
-      assert startTimestampMillis > 0;
-      int index = (int) ((startTimestampMillis - startTimestamp) / SAMPLING_PERIOD_MILLIS);
+      long recordTimestampMillis = source.getFiredTimestampMillis(session);
+      assert recordTimestampMillis > 0;
+      return this.active(recordTimestampMillis);
+   }
+
+   private StatisticsSnapshot active(long recordTimestampMillis) {
+      int index = (int) ((recordTimestampMillis - startTimestamp) / SAMPLING_PERIOD_MILLIS);
       AtomicReferenceArray<StatisticsSnapshot> active = this.active;
       if (index >= active.length()) {
          active = resizeArray(active, index);
          this.active = active;
       } else if (index < 0) {
-         log.error("Record start timestamp {} predates statistics start {}", startTimestampMillis,
+         log.error("Record start timestamp {} predates statistics start {}", recordTimestampMillis,
                startTimestamp);
          index = 0;
       }

--- a/cli/src/main/java/io/hyperfoil/cli/commands/WrkAbstract.java
+++ b/cli/src/main/java/io/hyperfoil/cli/commands/WrkAbstract.java
@@ -173,7 +173,7 @@ public abstract class WrkAbstract extends BaseStandaloneCommand {
          boolean result = awaitBenchmarkResult(run, invocation);
 
          RequestStatisticsResponse total = run.statsTotal();
-         wrkCommandResult = new WrkCommandResult(run, total);
+         wrkCommandResult = new WrkCommandResult(run, total, run.series("test", 0, "request"));
 
          if (result) {
             if (output != null && !output.isBlank()) {
@@ -249,7 +249,7 @@ public abstract class WrkAbstract extends BaseStandaloneCommand {
       protected abstract PhaseBuilder<?> phaseConfig(PhaseBuilder.Catalog catalog, WrkScenario.PhaseType phaseType, long durationMs);
 
       private void printStats(StatisticsSummary stats, AbstractHistogram histogram, List<StatisticsSummary> series,
-            CommandInvocation invocation) {
+                              CommandInvocation invocation) {
          TransferSizeRecorder.Stats transferStats = (TransferSizeRecorder.Stats) stats.extensions.get("transfer");
          HttpStats httpStats = HttpStats.get(stats);
          double durationSeconds = (stats.endTime - stats.startTime) / 1000d;
@@ -324,12 +324,14 @@ public abstract class WrkAbstract extends BaseStandaloneCommand {
    }
 
    public static class WrkCommandResult {
-      Client.RunRef run;
-      RequestStatisticsResponse requestStatisticsResponse;
+      final Client.RunRef run;
+      final RequestStatisticsResponse requestStatisticsResponse;
+      final List<StatisticsSummary> series;
 
-      public WrkCommandResult(Client.RunRef run, RequestStatisticsResponse requestStatisticsResponse) {
+      public WrkCommandResult(Client.RunRef run, RequestStatisticsResponse requestStatisticsResponse, List<StatisticsSummary> series) {
          this.run = run;
          this.requestStatisticsResponse = requestStatisticsResponse;
+         this.series = series;
       }
 
       public Client.RunRef getRun() {
@@ -338,6 +340,10 @@ public abstract class WrkAbstract extends BaseStandaloneCommand {
 
       public RequestStatisticsResponse getRequestStatisticsResponse() {
          return requestStatisticsResponse;
+      }
+
+      public List<StatisticsSummary> getSeries() {
+         return series;
       }
    }
 }

--- a/core/src/main/java/io/hyperfoil/core/steps/DelaySessionStartStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/DelaySessionStartStep.java
@@ -76,6 +76,7 @@ public class DelaySessionStartStep implements Step, ResourceUtilizer {
       public double period;
       public ScheduledFuture<?> future;
       public PhaseInstance phase;
+      private long firedTimestampMillis;
 
       public long lastStartTime() {
          return startTimeWithOffset + (long) ((iteration - 1) * period);
@@ -97,6 +98,16 @@ public class DelaySessionStartStep implements Step, ResourceUtilizer {
       @Override
       public long getStartTimestampNanos(Session session) {
          throw new IllegalStateException("Not allowed to call this method");
+      }
+
+      @Override
+      public long getFiredTimestampMillis(Session session) {
+         return this.firedTimestampMillis;
+      }
+
+      @Override
+      public void setFiredTimestampMillis(Session session) {
+         this.firedTimestampMillis = System.currentTimeMillis();
       }
    }
 }

--- a/core/src/main/java/io/hyperfoil/core/steps/StopwatchBeginStep.java
+++ b/core/src/main/java/io/hyperfoil/core/steps/StopwatchBeginStep.java
@@ -31,6 +31,7 @@ public class StopwatchBeginStep implements Step, ResourceUtilizer {
       if (!key.isSet(session)) {
          StartTime startTime = (StartTime) key.activate(session);
          startTime.createStartTimestamp(session, useSessionStartTime, startTime.timestamps);
+         startTime.firedTimestampMillis = System.currentTimeMillis();
       }
       return true;
    }
@@ -43,6 +44,7 @@ public class StopwatchBeginStep implements Step, ResourceUtilizer {
 
    static class StartTime implements StartTimeSource {
       final long[] timestamps = new long[2];
+      long firedTimestampMillis;
 
       @Override
       public long getStartTimestampMillis(Session session) {
@@ -52,6 +54,16 @@ public class StopwatchBeginStep implements Step, ResourceUtilizer {
       @Override
       public long getStartTimestampNanos(Session session) {
          return this.timestamps[1];
+      }
+
+      @Override
+      public long getFiredTimestampMillis(Session session) {
+         return this.firedTimestampMillis;
+      }
+
+      @Override
+      public void setFiredTimestampMillis(Session session) {
+         this.firedTimestampMillis = System.currentTimeMillis();
       }
    }
 

--- a/core/src/test/java/io/hyperfoil/core/session/BaseScenarioTest.java
+++ b/core/src/test/java/io/hyperfoil/core/session/BaseScenarioTest.java
@@ -63,17 +63,11 @@ public abstract class BaseScenarioTest extends BaseBenchmarkParserTest {
       public void accept(Phase phase, int stepId, String metric, StatisticsSnapshot snapshot, CountDown countDown) {
          log.debug("Adding stats for {}/{}/{} - #{}: {} requests {} responses", phase.name, stepId, metric,
                snapshot.sequenceId, snapshot.requestCount, snapshot.responseCount);
-         Map<String, StatisticsSnapshot> stats = phaseStats.get(phase.name);
-         if (stats == null) {
-            stats = new HashMap<>();
-            phaseStats.put(phase.name, stats);
-         }
-         StatisticsSnapshot metricValue = stats.get(metric);
-         if (metricValue == null) {
-            metricValue = new StatisticsSnapshot();
-            stats.put(metric, metricValue);
-         }
-         metricValue.add(snapshot);
+
+         // Aggregate statistics per phase and metric
+         phaseStats.computeIfAbsent(phase.name, k -> new HashMap<>())
+               .computeIfAbsent(metric, k -> new StatisticsSnapshot())
+               .add(snapshot);
       }
 
       public Map<String, StatisticsSnapshot> firstPhaseStats() {

--- a/core/src/test/java/io/hyperfoil/core/statistics/StatisticsAggregationTest.java
+++ b/core/src/test/java/io/hyperfoil/core/statistics/StatisticsAggregationTest.java
@@ -207,9 +207,11 @@ public class StatisticsAggregationTest {
    class TestStartTimeSource implements StartTimeSource {
 
       private final long startTimestampMillis;
+      private final long firedTimestampMillis;
 
-      TestStartTimeSource(long startTimestampMillis) {
-         this.startTimestampMillis = startTimestampMillis;
+      TestStartTimeSource(long timestampMillis) {
+         this.startTimestampMillis = timestampMillis;
+         this.firedTimestampMillis = timestampMillis;
       }
 
       @Override
@@ -220,6 +222,16 @@ public class StatisticsAggregationTest {
       @Override
       public long getStartTimestampNanos(Session session) {
          return 0;
+      }
+
+      @Override
+      public long getFiredTimestampMillis(Session session) {
+         return this.firedTimestampMillis;
+      }
+
+      @Override
+      public void setFiredTimestampMillis(Session session) {
+         throw new UnsupportedOperationException("Use the constructor instead");
       }
    }
 }

--- a/hotrod/src/main/java/io/hyperfoil/hotrod/resource/HotRodResource.java
+++ b/hotrod/src/main/java/io/hyperfoil/hotrod/resource/HotRodResource.java
@@ -7,6 +7,7 @@ import io.hyperfoil.api.session.Session;
 public class HotRodResource implements Session.Resource {
 
    public final long[] timestamps = new long[2];
+   private long firedTimestampMillis;
    private CompletableFuture future;
 
    public void set(CompletableFuture future) {
@@ -23,6 +24,14 @@ public class HotRodResource implements Session.Resource {
 
    public long getStartTimestampNanos() {
       return timestamps[1];
+   }
+
+   public long getFiredTimestampMillis() {
+      return firedTimestampMillis;
+   }
+
+   public void setFiredTimestampMillis(long firedTimestampMillis) {
+      this.firedTimestampMillis = firedTimestampMillis;
    }
 
    public static class Key implements Session.ResourceKey<HotRodResource> {

--- a/hotrod/src/main/java/io/hyperfoil/hotrod/steps/HotRodRequestStep.java
+++ b/hotrod/src/main/java/io/hyperfoil/hotrod/steps/HotRodRequestStep.java
@@ -68,6 +68,7 @@ public class HotRodRequestStep extends StatisticsStep implements ResourceUtilize
       HotRodResource resource = session.getResource(futureWrapperKey);
 
       this.createStartTimestamp(session, this.useSessionStartTime, resource.timestamps);
+      this.setFiredTimestampMillis(session);
 
       CompletableFuture future;
       if (HotRodOperation.PUT.equals(operation)) {
@@ -130,5 +131,19 @@ public class HotRodRequestStep extends StatisticsStep implements ResourceUtilize
       assert session.executor().inEventLoop();
       HotRodResource resource = session.getResource(futureWrapperKey);
       return resource.getStartTimestampNanos();
+   }
+
+   @Override
+   public long getFiredTimestampMillis(Session session) {
+      assert session.executor().inEventLoop();
+      HotRodResource resource = session.getResource(futureWrapperKey);
+      return resource.getFiredTimestampMillis();
+   }
+
+   @Override
+   public void setFiredTimestampMillis(Session session) {
+      assert session.executor().inEventLoop();
+      HotRodResource resource = session.getResource(futureWrapperKey);
+      resource.setFiredTimestampMillis(System.currentTimeMillis());
    }
 }

--- a/http/src/main/java/io/hyperfoil/http/api/HttpRequest.java
+++ b/http/src/main/java/io/hyperfoil/http/api/HttpRequest.java
@@ -67,6 +67,7 @@ public class HttpRequest extends Request {
       }
 
       attach(connection);
+      setFiredTimestampMillis(this.session);
       connection.attach(pool);
       connection.request(this, headerAppenders, injectHostHeader, bodyGenerator);
    }
@@ -156,5 +157,10 @@ public class HttpRequest extends Request {
    @Override
    public long getStartTimestampNanos(Session session) {
       return this.startTimestampNanos();
+   }
+
+   @Override
+   public long getFiredTimestampMillis(Session session) {
+      return this.firedTimestampMillis();
    }
 }

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/BaseWrkBenchmarkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/BaseWrkBenchmarkTest.java
@@ -60,6 +60,11 @@ public abstract class BaseWrkBenchmarkTest extends BaseBenchmarkTest {
             ctx.response().end("1s");
          });
       });
+      router.route("/50ms").handler(ctx -> {
+         ctx.vertx().setTimer(50, id -> {
+            ctx.response().end("50ms!");
+         });
+      });
       return router;
    }
 }

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
@@ -149,7 +149,7 @@ public class WrkTest extends BaseWrkBenchmarkTest {
    public void testWrk2ReqSec() throws CommandNotFoundException {
       int seconds = 5;
       Wrk2 cmd = new Wrk2();
-      int result = cmd.exec(new String[] { "-t", "1", "-c", "5", "-d", seconds + "s", "-R", "2000", "--timeout", "2s",
+      int result = cmd.exec(new String[] { "-t", "1", "-c", "5", "-d", seconds + "s", "-R", "1000", "--timeout", "1s",
             "localhost:" + httpServer.actualPort() + "/50ms" });
 
       CommandContainer<HyperfoilCommandInvocation> commandContainer = cmd.getCommandRegistry().getCommand("wrk2", null);

--- a/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
+++ b/test-suite/src/test/java/io/hyperfoil/benchmark/standalone/WrkTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 
 import org.aesh.command.CommandNotFoundException;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.hyperfoil.api.statistics.StatisticsSummary;
 import io.hyperfoil.benchmark.BaseWrkBenchmarkTest;
 import io.hyperfoil.cli.commands.Wrk;
 import io.hyperfoil.cli.commands.Wrk2;
@@ -141,5 +143,24 @@ public class WrkTest extends BaseWrkBenchmarkTest {
       }
       // we are expecting at least one failed SLA because of the high rate
       assertTrue(failedSLA);
+   }
+
+   @Test
+   public void testWrk2ReqSec() throws CommandNotFoundException {
+      int seconds = 5;
+      Wrk2 cmd = new Wrk2();
+      int result = cmd.exec(new String[] { "-t", "1", "-c", "5", "-d", seconds + "s", "-R", "2000", "--timeout", "2s",
+            "localhost:" + httpServer.actualPort() + "/50ms" });
+
+      CommandContainer<HyperfoilCommandInvocation> commandContainer = cmd.getCommandRegistry().getCommand("wrk2", null);
+      ProcessedCommand processedCommand = commandContainer.getParser().getProcessedCommand();
+      Wrk2.Wrk2Command wrk2Command = (Wrk2.Wrk2Command) processedCommand.getCommand();
+      WrkAbstract.WrkCommandResult wrkCommandResult = wrk2Command.getWrkCommandResult();
+
+      assertEquals(CommandResult.SUCCESS.getResultValue(), result);
+      List<StatisticsSummary> series = wrkCommandResult.getSeries();
+      assert series != null;
+      int size = series.size();
+      assertTrue(size >= (seconds - 1) && size <= (seconds + 1), "Expected ~" + seconds + " buckets, but got: " + size);
    }
 }


### PR DESCRIPTION
## Description

Resolves an issue where wrk2 mode reported unrealistically high Req/Sec during server saturation. By bucketing statistics using the moment the request is actually fired (`firedTimestampMillis`) rather than its intended schedule, metrics correctly span the full test duration instead of collapsing.

Fixes: https://github.com/Hyperfoil/Hyperfoil/issues/860

## The Solution
The patch switches Hyperfoil's statistic bucketing strategy from Intended Time to Fired Time (Option B from the issue discussion).

## Key Changes Introduced
#### 1. Tracking Actual Fired Timestamps (StartTimeSource & Implementations)
- Added getFiredTimestampMillis() and setFiredTimestampMillis() methods to the StartTimeSource interface.
- Updated request implementations (Request.java, HttpRequest.java, HotRodRequestStep.java, StopwatchBeginStep.java, DelaySessionStartStep.java) to capture System.currentTimeMillis() at the exact moment the request is sent/fired.

#### 2. Changing the Bucketing Calculation (Statistics.java)

- Modified Statistics#active(...) to compute the sampling array index using the fired timestamp instead of the intended start timestamp:

```java
// Old:
long startTimestampMillis = source.getStartTimestampMillis(session);

// New:
long recordTimestampMillis = source.getFiredTimestampMillis(session);
int index = (int) ((recordTimestampMillis - startTimestamp) / SAMPLING_PERIOD_MILLIS);
```

- This ensures requests fall into time buckets corresponding to when Hyperfoil actually generated the traffic.

#### 3. Exposing Time-Series Data in CLI (WrkAbstract.java)
- Updated WrkCommandResult to include the metric time series list (List<StatisticsSummary> series). This enables CLI tools and integration tests to verify the distribution of stats across time buckets.

#### 4. Regression Test (WrkTest.java)
- Added testWrk2ReqSec: Runs a 15-second test (-d 15s) against a /50ms endpoint and asserts that series.size() == 15. This verifies that statistics are now distributed across 15 individual 1-second buckets instead of collapsing.

## Report
Before this change the report was (1 bucket per phase)
<img width="1909" height="498" alt="image" src="https://github.com/user-attachments/assets/53d04e1d-2ddc-4dcf-a00f-4ea6c0ff6f6a" />

After this change the report will be ( distributed buckets per fire time)
<img width="1899" height="487" alt="image" src="https://github.com/user-attachments/assets/539050ce-b7a6-47a3-8b78-48345c01fc23" />
